### PR TITLE
Fix some minor bug bumping version 0.0.2 to 0.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safelz4_py"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = """
 High-performance Rust bindings to the LZ4 compression algorithm. Ideal for fast, lightweight data compression in systems programming, file formats, or network protocols. 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Special thanks also to the maintainers of the [lz4_flex](https://github.com/PSei
 
 | Python Library    | Build Status | Version | Licence | 
 | -------- | ------- | ------- | ------- |
-| [python-lz4](https://github.com/python-lz4/python-lz4) | ![](https://pypi-camo.freetls.fastly.net/6d3d73bb6f61ccadc08c11e3dcee01e847fc768e/68747470733a2f2f6769746875622e636f6d2f707974686f6e2d6c7a342f707974686f6e2d6c7a342f616374696f6e732f776f726b666c6f77732f6275696c645f646973742e796d6c2f62616467652e737667)    | ![](https://img.shields.io/pypi/v/lz4) | ![PyPI - License](https://img.shields.io/pypi/l/lz4)
+| [python-lz4](https://github.com/python-lz4/python-lz4) | [![Build Status](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml/badge.svg)](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml)| ![](https://img.shields.io/pypi/v/lz4) | ![PyPI - License](https://img.shields.io/pypi/l/lz4)
 
 
 

--- a/py/safelz4/frame/__init__.py
+++ b/py/safelz4/frame/__init__.py
@@ -316,7 +316,7 @@ def open(
     block_size: _frame.BlockSize = BlockSize.Auto,
     block_mode: _frame.BlockMode = BlockMode.Independent,
     block_checksums: Optional[bool] = None,
-    dict_id: Optional[bool] = None,
+    dict_id: Optional[int] = None,
     content_checksum: Optional[bool] = None,
     content_size: Optional[int] = None,
     legacy_frame: Optional[bool] = None,

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -453,7 +453,15 @@ class FrameEncoderWriter:
     """
 
     def __new__(
-        self, filename: str, info: Optional[FrameInfo] = None
+        self,
+        filename: str,
+        block_size: BlockSize = ...,
+        block_mode: BlockMode = ...,
+        block_checksums: Optional[bool] = ...,
+        dict_id: Optional[int] = ...,
+        content_checksum: Optional[bool] = ...,
+        content_size: Optional[int] = ...,
+        legacy_frame: Optional[bool] = ...,
     ) -> Self: ...
     def offset(self) -> int:
         """
@@ -613,7 +621,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         block_size: BlockSize = ...,
         block_mode: BlockMode = ...,
         block_checksums: Optional[bool] = ...,
-        dict_id: Optional[bool] = ...,
+        dict_id: Optional[int] = ...,
         content_checksum: Optional[bool] = ...,
         content_size: Optional[int] = ...,
         legacy_frame: Optional[bool] = ...,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1062,7 +1062,7 @@ impl PyFrameDecoderReader {
         })
     }
 
-    ///
+    /// Return mode of the reader.
     pub fn mode(&self) -> PyResult<&str> {
         Ok("rb")
     }
@@ -1219,6 +1219,7 @@ impl PyFrameEncoderWriter {
 impl PyFrameEncoderWriter {
     #[new]
     #[pyo3(signature = (filename, block_size, block_mode, block_checksums = None, dict_id = None, content_checksum = None, content_size = None, legacy_frame = None))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         filename: PathBuf,
         block_size: PyBlockSize,


### PR DESCRIPTION
## 📋 Description

This PR includes minor improvements to the type stubs in``py/safelz4/frame/__init__.pyi`` 
- Added ``DecoderReaderWrapper`` and ``EncoderWriterWrapper`` to the stub definitions.
- Fixed type annotations for ``open()`` write-mode overload, and ``FrameEncoderWriter`` parameters.



```py 
# py/safelz4/frame/__init__.py
def open(
    filename: Union[str, os.PathLike],
    mode: Optional[Literal["rb", "rb|lz4", "wb", "wb|lz4"]] = None,
    block_size: _frame.BlockSize = BlockSize.Auto,
    block_mode: _frame.BlockMode = BlockMode.Independent,
    block_checksums: Optional[bool] = None,
    dict_id: Optional[int] = None,
    content_checksum: Optional[bool] = None,
    content_size: Optional[int] = None,
    legacy_frame: Optional[bool] = None,
) -> Union[DecoderReaderWrapper, EncoderWriterWrapper]:

# py/safelz4/frame/__init__.pyi
@overload
def open(
    filename: Union[str, os.PathLike],
    mode: Optional[Literal["wb", "wb|lz4"]] = None,
    block_size: BlockSize = BlockSize.Auto,
    block_mode: BlockMode = BlockMode.Independent,
    block_checksums: Optional[bool] = None,
    dict_id: Optional[int] = None,
    content_checksum: Optional[bool] = None,
    content_size: Optional[int] = None,
    legacy_frame: Optional[bool] = None,
) -> EncoderWriterWrapper: ...
```