### PR TITLE
core: use IO[bytes] as base for encoder/decoder wrappers

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.version.python }}
           architecture: ${{ matrix.version.arch }}
 
       - name: Install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,6 @@ Thank you for your interest in contributing to safelz4! This document provides g
 ## Development Setup
 
 ```bash
-git clone https://github.com/yourusername/safelz4.git
-cd safelz4
-python -m pip install -e .
-python -m pip install -r requirements-dev.txt
-```
-
-```bash
 git clone https://github.com/LVivona/safelz4.git
 cd safelz4
 pip install setuptools_rust
@@ -45,7 +38,7 @@ To check if your code falls under this style scope just run.
 make check
 ```
 
-You can also just apply them via:
+You can also just apply them via **NOTE**: it may lint everything, so always check.:
 ```bash
 # run lint format on python/rust
 make lint
@@ -53,22 +46,33 @@ make lint
 
 ### Documentation
 - All public/private functions must have docstrings
+- It's optional to add Raised objects.
 
 Example:
 ```python
-def decompress_prepend_size_with_dict(input: bytes, ext_dict: bytes) -> bytes:
-    """
-    Decompress input bytes using a user-provided dictionary of bytes, size is already pre-appended.
-    Args:
-        input (`bytes`):
-            fixed set of bytes to be decompressed.
-        ext_dict (`bytes`):
-            Dictionary used for decompression.
+    def readline(self, limit: int = -1) -> bytes:
+        """
+        Read and return one line from the stream.
 
-    Returns:
-        (`bytes`): decompressed data.
-    """
-    ...
+        Args:
+            limit (`int`, **optional**, default: -1):
+                Maximum number of bytes to read.
+                If -1, read until newline or EOF.
+
+        Returns:
+            (`bytes`): A single line including the trailing newline character,
+                or empty bytes if EOF is reached.
+
+        Raises:
+            (`ValueError`):
+                Rasied if the file is closed
+            (`ReadError`):
+                Raised when there is an issue reading the block.
+            (`DecompressionError`):
+                Raised decompression method is not supported or when
+                the data cannot be decoded properly.
+        """
+        ...
 ```
 
 ### Testing
@@ -116,7 +120,6 @@ Fixes #123
 All submissions require review. We use GitHub pull requests for this purpose. Reviewers will check for:
 
 - Code quality and style
-- Test coverage
 - Documentation completeness
 - Performance implications
 - Security considerations

--- a/fuzz/fuzz_context_manager.py
+++ b/fuzz/fuzz_context_manager.py
@@ -1,0 +1,40 @@
+import atheris
+import sys
+import tempfile
+
+import safelz4
+from safelz4.error import LZ4Exception
+
+def fuzz_is_framefile(data: bytes):
+    try:
+        safelz4.is_framefile(data)
+    except (LZ4Exception, ValueError, AttributeError):
+        pass
+
+
+def fuzz_wrapped_decoder(data: bytes):
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".lz4") as tmp:
+            tmp.write(data)
+            tmp.flush()
+            try:
+                with safelz4.open(tmp.name, "rb") as f:
+                    f.read()
+                    f.readlines()
+            except (LZ4Exception, ValueError, EOFError):
+                pass
+    except Exception:
+        pass
+
+
+def TestOneInput(data: bytes) -> None:
+    fuzz_wrapped_decoder(data)
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_decomp_corrupt_frame.py
+++ b/fuzz/fuzz_decomp_corrupt_frame.py
@@ -4,18 +4,17 @@ import atheris
 with atheris.instrument_imports():
     import safelz4
 
-
 def TestDecompCorruptFrame(data: bytes):
     try:
         safelz4.compress(data)
     except safelz4.LZ4Exception:
         return
-
-    # allocate memeory to dynamic byte array
+    
+    # allocate memory to dynamic byte array
     buffer = bytearray()
-
-    # no prefic
-    for prefix in [b"", b"\x04, \x22, \x4d, \x18"]:
+    
+    # no prefix
+    for prefix in [b"", b"\x04\x22\x4d\x18"]:
         buffer.clear()
         buffer.extend(prefix)
         buffer.extend(data)
@@ -23,23 +22,17 @@ def TestDecompCorruptFrame(data: bytes):
             safelz4.compress(buffer)
         except safelz4.LZ4Exception:
             return
-
-    for preix in [
-        [
-            "\x04",
-            "\x22",
-            "\x4d",
-            "\x18",
-            "\x60",
-            "\x40",
-            "\x82",
-        ]["\x04", "\x22", "\x4d", "\x18", "\x40", "\x40", "\xc0"]
+    
+    for prefix in [
+        b"\x04\x22\x4d\x18\x60\x40\x82",
+        b"\x04\x22\x4d\x18\x40\x40\xc0"
     ]:
         try:
             buffer.clear()
             buffer.extend(prefix)
             buffer.extend(data)
             safelz4.compress(buffer)
+            
             # use prefix then 2 valid blocks of data
             buffer.clear()
             buffer.extend(prefix)
@@ -53,7 +46,6 @@ def TestDecompCorruptFrame(data: bytes):
             continue
         except OverflowError:
             return
-
 
 atheris.Setup(sys.argv, TestDecompCorruptFrame)
 atheris.Fuzz()

--- a/fuzz/fuzz_is_framefile.py
+++ b/fuzz/fuzz_is_framefile.py
@@ -1,0 +1,23 @@
+import atheris
+import sys
+
+import safelz4
+from safelz4.error import LZ4Exception
+def fuzz_is_framefile(data: bytes):
+    try:
+        safelz4.is_framefile(data)
+    except (LZ4Exception, ValueError, AttributeError):
+        pass
+
+
+def TestOneInput(data: bytes) -> None:
+    fuzz_is_framefile(data)
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_roundtrip_frame.py
+++ b/fuzz/fuzz_roundtrip_frame.py
@@ -20,7 +20,6 @@ def TestRoundTripFrame(data: bytes):
     # Extract seeds from the fuzzer data
     fdp = atheris.FuzzedDataProvider(data)
     data_size_seed = fdp.ConsumeInt(4)  # Use 4 bytes for seed
-    chunk_size_seed = fdp.ConsumeInt(4)  # Use 4 bytes for seed
 
     # Get remaining data as sample
     sample = fdp.ConsumeBytes(fdp.remaining_bytes())

--- a/py/safelz4/frame/__init__.py
+++ b/py/safelz4/frame/__init__.py
@@ -100,9 +100,11 @@ class DecoderReaderWrapper(io.BufferedIOBase):
     standard I/O system.
     """
 
-    def __init__(self, filename: str) -> None:
+    def __init__(
+        self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
+    ) -> None:
         # Initialize the parent FrameDecoderReader
-        self._inner = _frame.FrameDecoderReader(filename)
+        self._inner = _frame.FrameDecoderReader(filename, mode)
 
     # BufferedIOBase required methods
     def readable(self) -> bool:
@@ -370,9 +372,9 @@ def open(
     ```
     """
     if mode is None:
-        return DecoderReaderWrapper(filename)
+        return DecoderReaderWrapper(filename, mode="rb")
     elif mode in ("rb", "rb|lz4"):
-        return DecoderReaderWrapper(filename)
+        return DecoderReaderWrapper(filename, mode)
     elif mode in ("wb", "wb|lz4"):
         return EncoderWriterWrapper(
             filename,

--- a/py/safelz4/frame/__init__.py
+++ b/py/safelz4/frame/__init__.py
@@ -1,6 +1,7 @@
 import os
 import io
 from typing import Union, Optional, Literal, IO, List
+from types import TracebackType
 from safelz4.error import LZ4Exception
 from safelz4._safelz4_rs import _frame
 
@@ -110,7 +111,7 @@ class WrappedDecoderReader(IO[bytes]):
         filename: Union[os.PathLike, str],
         mode: Optional[Literal["rb", "rb|lz4"]] = None,
     ) -> None:
-        self._inner = _frame.FrameDecoderReader(filename, mode)
+        self._inner = _frame.FrameDecoderReader(filename=filename, mode=mode)
 
     @property
     def mode(self) -> str:
@@ -203,10 +204,20 @@ class WrappedDecoderReader(IO[bytes]):
 
         Returns:
             (`bytes`): block read from the stream return sized bytes of said
-                       block
+                       block.
 
         Raises:
-            (`ValueError`): If the file is closed
+            (`ValueError`):
+                Rasied if the file is closed
+            (`ReadError`):
+                Raised if the input stream cannot be read or is incomplete.
+            (`DecompressionError`):
+                Raised if the source buffer cannot be decompressed
+                into the destination buffer, typically due to corrupt or
+                malformed input.
+            (`LZ4Exception`):
+                Raised if a block checksum does not match the expected value,
+                indicating potential data corruption.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -217,16 +228,22 @@ class WrappedDecoderReader(IO[bytes]):
         Read and return one line from the stream.
 
         Args:
-            limit (int, **optional**, default: -1):
+            limit (`int`, **optional**, default: -1):
                 Maximum number of bytes to read.
                 If -1, read until newline or EOF.
 
         Returns:
-            bytes: A single line including the trailing newline character,
+            (`bytes`): A single line including the trailing newline character,
                 or empty bytes if EOF is reached.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`):
+                Rasied if the file is closed
+            (`ReadError`):
+                Raised when there is an issue reading the block.
+            (`DecompressionError`):
+                Raised decompression method is not supported or when
+                the data cannot be decoded properly.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -262,7 +279,8 @@ class WrappedDecoderReader(IO[bytes]):
             (`List[bytes]`): List of lines, each including trailing newline.
 
         Raises:
-            (`ValueError`): If the file is closed
+            (`ValueError`):
+                Raised if the file is closed
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -290,17 +308,17 @@ class WrappedDecoderReader(IO[bytes]):
             self._inner.close()
 
     def __enter__(self) -> Self:
-        """
-        Context manager entry — returns self.
-
-        Returns:
-            (`WrappedDecoderReader`): The reader wrapper instance itself.
-        """
+        """Context manager entry"""
         return self
 
-    def __exit__(self, type, value, traceback) -> None:
-        """Context manager exit — flushes and closes the writer."""
-        self._inner.__exit__(type, value, traceback)
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Context manager exit"""
+        self._inner.__exit__(exc_type, exc_value, traceback)
 
     def __str__(self):
         return f"<frame.EncoderReader name={self._name}>"
@@ -329,17 +347,16 @@ class WrappedEncoderWriter(IO[bytes]):
         legacy_frame: Optional[bool] = None,
     ) -> None:
         self._inner = _frame.FrameEncoderWriter(
-            filename,
-            mode,
-            block_size,
-            block_mode,
-            block_checksums,
-            dict_id,
-            content_checksum,
-            content_size,
-            legacy_frame,
+            filename=filename,
+            mode=mode,
+            block_size=block_size,
+            block_mode=block_mode,
+            block_checksums=block_checksums,
+            dict_id=dict_id,
+            content_checksum=content_checksum,
+            content_size=content_size,
+            legacy_frame=legacy_frame,
         )
-        self._name = filename
 
     @property
     def mode(self) -> str:
@@ -367,7 +384,7 @@ class WrappedEncoderWriter(IO[bytes]):
 
     def writable(self) -> bool:
         """Returns True since this is a writable stream."""
-        return not self._inner.closed
+        return not self.closed
 
     def seekable(self) -> bool:
         """
@@ -378,7 +395,7 @@ class WrappedEncoderWriter(IO[bytes]):
 
     def tell(self) -> int:
         """Returns current position in the stream."""
-        return self._inner.offset()
+        return self.offset
 
     def write(self, data: bytes) -> int:
         """
@@ -393,6 +410,11 @@ class WrappedEncoderWriter(IO[bytes]):
         Raises:
             (`ValueError`): If the file is closed.
             (`TypeError`): If data is not a bytes-like object.
+            (`LZ4Exception`):
+                within FrameEncoderWriter rasied when the file is closed.
+            (`CompressionError`):
+                raised when a compression method is not supported or when
+                the data cannot be encoded properly.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -412,7 +434,15 @@ class WrappedEncoderWriter(IO[bytes]):
             lines (`List[bytes]`): Iterable of bytes-like objects.
 
         Raises:
-            (`ValueError`): If the file is closed.
+            (`ValueError`):
+                Raised when file is closed.
+            (`TypeError`):
+                Rasied if data is not a bytes-like object.
+            (`LZ4Exception`):
+                Rasied if within FrameEncoderWriter, when the file is closed.
+            (`CompressionError`):
+                Raised when a compression method is not supported or when
+                the data cannot be encoded properly.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -425,7 +455,10 @@ class WrappedEncoderWriter(IO[bytes]):
         Flush the internal buffer to disk.
 
         Raises:
-            (`ValueError`): If the file is closed.
+            (`LZ4Exception`):
+                Rasied when the file is closed.
+            (`IOError`):
+                Raised when the file is unable to flush.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -436,25 +469,24 @@ class WrappedEncoderWriter(IO[bytes]):
         Close the stream and flush any remaining data.
 
         Raises:
-            (`IOError`): If flushing fails during close.
+            (`IOError`):
+                Raised when the file is unable to flush.
         """
         if not self.closed:
             self._inner.close()
 
     def __enter__(self) -> Self:
-        """
-        Context manager entry.
-
-        Returns:
-            (`WrappedEncoderWriter`): The writer wrapper instance itself.
-        """
+        """Context manager entry."""
         return self
 
-    def __exit__(self, type, value, traceback) -> None:
-        """
-        Context manager exit.
-        """
-        self._inner.__exit__(type, value, traceback)
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Context manager exit."""
+        self._inner.__exit__(exc_type, exc_value, traceback)
 
     def __str__(self):
         return f"<frame.WrappedDecoderReader name={self.name}>"
@@ -492,7 +524,7 @@ def open(
                 yield content
 
     # Writing LZ4 compressed data
-    with safelz4.lz4_open("datafile.lz4", "wb") as file:
+    with safelz4.open("datafile.lz4", "wb") as file:
         for content in chunk("datafile.txt", MEGABYTE):
             file.write(content)
     ```
@@ -504,7 +536,7 @@ def open(
 
     # Reading LZ4 compressed data
     chunk_size = 1024
-    with safelz4.lz4_open("datafile.lz4", "rb") as file:
+    with safelz4.open("datafile.lz4", "rb") as file:
         while content := file.read(chunk_size):
             print(content)
     ```
@@ -516,7 +548,7 @@ def open(
 
     # Reading without context manager
     chunk_size = 1024
-    file = safelz4.lz4_open("datafile.lz4", "rb")
+    file = safelz4.open("datafile.lz4", "rb")
     try:
         while content := file.read(chunk_size):
             print(content)

--- a/py/safelz4/frame/__init__.py
+++ b/py/safelz4/frame/__init__.py
@@ -1,14 +1,14 @@
 import os
 import io
-from typing import Union, Optional, Literal, Iterable, IO
+from typing import Union, Optional, Literal, IO, List
 from safelz4.error import LZ4Exception
 from safelz4._safelz4_rs import _frame
 
 try:
-    from typing import Buffer, Self
+    from typing import Self
 except ImportError:
     # NOTE For Python < 3.12
-    from typing_extensions import Buffer, Self
+    from typing_extensions import Self
 
 __all__ = [
     "FrameInfo",
@@ -98,19 +98,19 @@ def is_framefile(
         return False
 
 
-class DecoderReaderWrapper(IO[bytes]):
+class WrappedDecoderReader(IO[bytes]):
     """
-    Wrapper that combines io.BufferedIOBase interface with FrameDecoderReader
+    Wrapper that combines IO[bytes] interface with FrameDecoderReader
     functionality. This makes the LZ4 decoder compatible with Python's
     standard I/O system.
     """
 
     def __init__(
-        self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
+        self,
+        filename: Union[os.PathLike, str],
+        mode: Optional[Literal["rb", "rb|lz4"]] = None,
     ) -> None:
-        # Initialize the parent FrameDecoderReader
         self._inner = _frame.FrameDecoderReader(filename, mode)
-        self._name = filename
 
     @property
     def mode(self) -> str:
@@ -118,14 +118,64 @@ class DecoderReaderWrapper(IO[bytes]):
 
     @property
     def name(self) -> str:
-        return self._name
+        """return name of the file."""
+        return str(self._inner.name)
 
     @property
     def closed(self) -> bool:
         """Returns True if the file is closed."""
         return self._inner.closed
 
-    # BufferedIOBase required methods
+    @property
+    def block_size(self) -> _frame.BlockSize:
+        """
+        Returns the block size used in the LZ4 frame.
+
+        Returns:
+            (`BlockSize`): Enum representing the block size.
+        """
+        return self._inner.block_size
+
+    @property
+    def content_size(self) -> Optional[int]:
+        """
+        Returns the content size specified in the LZ4 frame header.
+
+        Returns:
+            (`Optional[int]`): Content size if present, or None.
+        """
+        return self._inner.content_size
+
+    @property
+    def block_checksum(self) -> bool:
+        """
+        Checks if block checksums are enabled for this frame.
+
+        Returns:
+            (`bool`): True if block checksums are enabled, False otherwise.
+        """
+        return self._inner.block_checksum
+
+    @property
+    def frame_info(self) -> _frame.FrameInfo:
+        """
+        Returns a copy of the parsed frame header.
+
+        Returns:
+            (`FrameInfo`): Frame header metadata object.
+        """
+        return self._inner.frame_info
+
+    @property
+    def current_block(self) -> int:
+        """
+        Return the amounf of blocks that has been read.
+
+        Returns:
+            (`int`): current block number
+        """
+        return self._inner.current_block
+
     def readable(self) -> bool:
         """Returns True since this is a readable stream."""
         return not self._inner.closed
@@ -142,7 +192,7 @@ class DecoderReaderWrapper(IO[bytes]):
         """Returns current position in block stream."""
         return self._inner.offset()
 
-    def read(self, n : int = -1) -> bytes:
+    def read(self, n: int = -1) -> bytes:
         """
         Read and return up to size bytes.
 
@@ -162,20 +212,54 @@ class DecoderReaderWrapper(IO[bytes]):
             raise ValueError("I/O operation on closed file")
         return self._inner.read(n)
 
-    def read1(self, size: int = -1) -> bytes:
-        """Read and return up to size bytes from the stream."""
-        return self.read(size)
-
-    def readinto(self, b: Buffer) -> Optional[int]:
+    def readline(self, limit: int = -1) -> bytes:
         """
-        Read data into a pre-allocated buffer.
+        Read and return one line from the stream.
 
         Args:
-            b (`Buffer`):
-                Buffer to read into (must support buffer protocol)
+            limit (int, **optional**, default: -1):
+                Maximum number of bytes to read.
+                If -1, read until newline or EOF.
 
         Returns:
-            (`Optional[int]`): Number of bytes read, or None if EOF
+            bytes: A single line including the trailing newline character,
+                or empty bytes if EOF is reached.
+
+        Raises:
+            ValueError: If the file is closed
+        """
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+
+        line = b""
+        bytes_read = 0
+
+        while limit == -1 or bytes_read < limit:
+            # Read one byte at a time to find newline
+            chunk = self._inner.read(1)
+            if not chunk:  # EOF reached
+                break
+
+            line += chunk
+            bytes_read += 1
+
+            # Check if we found a newline
+            if chunk == b"\n":
+                break
+
+        return line
+
+    def readlines(self, hint: int = -1) -> List[bytes]:
+        """
+        Read and return a list of lines from the stream.
+
+        Args:
+            hint (`int`, **optional**, default: -1):
+                Approximate number of bytes to read.
+                If -1, read all lines.
+
+        Returns:
+            (`List[bytes]`): List of lines, each including trailing newline.
 
         Raises:
             (`ValueError`): If the file is closed
@@ -183,18 +267,22 @@ class DecoderReaderWrapper(IO[bytes]):
         if self.closed:
             raise ValueError("I/O operation on closed file")
 
-        data = self.read(len(b))
-        if not data:
-            return 0
+        lines = []
+        bytes_read = 0
 
-        bytes_read = len(data)
-        b[:bytes_read] = data
-        return bytes_read
+        while hint == -1 or bytes_read < hint:
+            line = self.readline()
+            if not line:  # EOF reached
+                break
 
-    def readinto1(self, b: Buffer) -> int:
-        """Read data into buffer, single call to underlying raw stream."""
-        result = self.readinto(b)
-        return result if result is not None else 0
+            lines.append(line)
+            bytes_read += len(line)
+
+            # If hint is specified and we've read enough, break
+            if hint != -1 and bytes_read >= hint:
+                break
+
+        return lines
 
     def close(self) -> None:
         """Close the stream."""
@@ -206,7 +294,7 @@ class DecoderReaderWrapper(IO[bytes]):
         Context manager entry — returns self.
 
         Returns:
-            (`DecoderReaderWrapper`): The reader wrapper instance itself.
+            (`WrappedDecoderReader`): The reader wrapper instance itself.
         """
         return self
 
@@ -215,22 +303,22 @@ class DecoderReaderWrapper(IO[bytes]):
         self._inner.__exit__(type, value, traceback)
 
     def __str__(self):
-        return f"<frame.EncoderWriterWrapper name={self._name}>"
+        return f"<frame.EncoderReader name={self._name}>"
 
     def __repr__(self):
-        return f"<frame.EncoderWriterWrapper name={self._name}>"
+        return f"<frame.EncoderReader name={self._name}>"
 
 
-class EncoderWriterWrapper(IO[bytes]):
+class WrappedEncoderWriter(IO[bytes]):
     """
-    Wrapper that combines io.BufferedIOBase interface with
+    Wrapper that combines IO[bytes] interface with
     FrameEncoderWriter functionality. This makes the LZ4
     encoder compatible with Python's standard I/O system.
     """
 
     def __init__(
         self,
-        filename: str,
+        filename: Union[os.PathLike, str],
         mode: Literal["wb", "wb|lz4"],
         block_size: _frame.BlockSize = BlockSize.Auto,
         block_mode: _frame.BlockMode = BlockMode.Independent,
@@ -259,14 +347,20 @@ class EncoderWriterWrapper(IO[bytes]):
 
     @property
     def name(self) -> str:
-        return self._name
+        return str(self._inner.name)
 
     @property
     def closed(self) -> bool:
-        """Returns True if the file is closed."""
         return self._inner.closed
 
-    # BufferedIOBase required methods
+    @property
+    def offset(self) -> int:
+        return self._inner.offset
+
+    @property
+    def frame_info(self) -> _frame.FrameInfo:
+        return self._inner.frame_info
+
     def readable(self) -> bool:
         """Returns False since this is write-only."""
         return False
@@ -286,45 +380,39 @@ class EncoderWriterWrapper(IO[bytes]):
         """Returns current position in the stream."""
         return self._inner.offset()
 
-    def write(self, data: Union[bytes, bytearray, memoryview]) -> int:
+    def write(self, data: bytes) -> int:
         """
         Write data to the stream.
 
         Args:
-            data: Data to write (bytes-like object)
+            data (`bytes`): Data to write.
 
         Returns:
-            Number of bytes written
+            (`int`): Number of bytes written.
 
         Raises:
-            ValueError: If the file is closed
-            TypeError: If data is not a bytes-like object
+            (`ValueError`): If the file is closed.
+            (`TypeError`): If data is not a bytes-like object.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
 
-        # Convert to bytes if necessary
-        if isinstance(data, (bytearray, memoryview)):
-            data = bytes(data)
-        elif not isinstance(data, bytes):
+        if not isinstance(data, bytes):
             raise TypeError(
                 f"Expected bytes-like object, got {type(data).__name__}"
             )
 
-        # Use the inner writer's write method
         return self._inner.write(data)
 
-    def writelines(
-        self, lines: Iterable[Union[bytes, bytearray, memoryview]]
-    ) -> None:
+    def writelines(self, lines: List[bytes]) -> None:
         """
         Write a list of bytes-like objects to the stream.
 
         Args:
-            lines: Iterable of bytes-like objects
+            lines (`List[bytes]`): Iterable of bytes-like objects.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`): If the file is closed.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -337,7 +425,7 @@ class EncoderWriterWrapper(IO[bytes]):
         Flush the internal buffer to disk.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`): If the file is closed.
         """
         if self.closed:
             raise ValueError("I/O operation on closed file")
@@ -348,31 +436,31 @@ class EncoderWriterWrapper(IO[bytes]):
         Close the stream and flush any remaining data.
 
         Raises:
-            IOError: If flushing fails during close
+            (`IOError`): If flushing fails during close.
         """
         if not self.closed:
             self._inner.close()
 
     def __enter__(self) -> Self:
         """
-        Context manager entry — returns self.
+        Context manager entry.
 
         Returns:
-            (`EncoderWriterWrapper`): The writer wrapper instance itself.
+            (`WrappedEncoderWriter`): The writer wrapper instance itself.
         """
         return self
 
     def __exit__(self, type, value, traceback) -> None:
         """
-        Context manager exit — flushes and closes the writer.
+        Context manager exit.
         """
         self._inner.__exit__(type, value, traceback)
 
     def __str__(self):
-        return f"<frame.DecoderReaderWrapper name={self._name}>"
+        return f"<frame.WrappedDecoderReader name={self.name}>"
 
     def __repr__(self):
-        return f"<frame.DecoderReaderWrapper name={self._name}>"
+        return f"<frame.WrappedDecoderReader name={self.name}>"
 
 
 def open(
@@ -440,9 +528,9 @@ def open(
         mode = "rb"
 
     if mode in ("rb", "rb|lz4"):
-        return DecoderReaderWrapper(filename, mode)
+        return WrappedDecoderReader(filename, mode)
     elif mode in ("wb", "wb|lz4"):
-        return EncoderWriterWrapper(
+        return WrappedEncoderWriter(
             filename,
             mode,
             block_size,

--- a/py/safelz4/frame/__init__.py
+++ b/py/safelz4/frame/__init__.py
@@ -1,9 +1,14 @@
 import os
 import io
-from typing import Union, Optional, Literal, Iterable
-from typing_extensions import Buffer
+from typing import Union, Optional, Literal, Iterable, IO
 from safelz4.error import LZ4Exception
 from safelz4._safelz4_rs import _frame
+
+try:
+    from typing import Buffer, Self
+except ImportError:
+    # NOTE For Python < 3.12
+    from typing_extensions import Buffer, Self
 
 __all__ = [
     "FrameInfo",
@@ -93,7 +98,7 @@ def is_framefile(
         return False
 
 
-class DecoderReaderWrapper(io.BufferedIOBase):
+class DecoderReaderWrapper(IO[bytes]):
     """
     Wrapper that combines io.BufferedIOBase interface with FrameDecoderReader
     functionality. This makes the LZ4 decoder compatible with Python's
@@ -105,6 +110,20 @@ class DecoderReaderWrapper(io.BufferedIOBase):
     ) -> None:
         # Initialize the parent FrameDecoderReader
         self._inner = _frame.FrameDecoderReader(filename, mode)
+        self._name = filename
+
+    @property
+    def mode(self) -> str:
+        return self._inner.mode
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def closed(self) -> bool:
+        """Returns True if the file is closed."""
+        return self._inner.closed
 
     # BufferedIOBase required methods
     def readable(self) -> bool:
@@ -116,33 +135,14 @@ class DecoderReaderWrapper(io.BufferedIOBase):
         return False
 
     def seekable(self) -> bool:
-        """Returns True if seeking is supported."""
-        return not self._inner.closed
+        """Returns False since LZ4 streams don't support seeking."""
+        return False
 
     def tell(self) -> int:
         """Returns current position in block stream."""
-        return self.offset()
+        return self._inner.offset()
 
-    def seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
-        """
-        Seek to position in the stream.
-
-        Args:
-            pos: Position to seek to
-            whence: How to interpret pos (SEEK_SET, SEEK_CUR, SEEK_END)
-
-        Returns:
-            New absolute position
-
-        Raises:
-            ValueError: If the file is closed
-            io.UnsupportedOperation: If seeking is not supported
-        """
-        if self.closed:
-            raise ValueError("I/O operation on closed file")
-        raise io.UnsupportedOperation("seek")
-
-    def read(self, size: Optional[int] = -1) -> bytes:
+    def read(self, n : int = -1) -> bytes:
         """
         Read and return up to size bytes.
 
@@ -158,7 +158,9 @@ class DecoderReaderWrapper(io.BufferedIOBase):
         Raises:
             (`ValueError`): If the file is closed
         """
-        return self._inner.read(size)
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        return self._inner.read(n)
 
     def read1(self, size: int = -1) -> bytes:
         """Read and return up to size bytes from the stream."""
@@ -194,8 +196,32 @@ class DecoderReaderWrapper(io.BufferedIOBase):
         result = self.readinto(b)
         return result if result is not None else 0
 
+    def close(self) -> None:
+        """Close the stream."""
+        if not self.closed:
+            self._inner.close()
 
-class EncoderWriterWrapper(io.BufferedIOBase):
+    def __enter__(self) -> Self:
+        """
+        Context manager entry — returns self.
+
+        Returns:
+            (`DecoderReaderWrapper`): The reader wrapper instance itself.
+        """
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:
+        """Context manager exit — flushes and closes the writer."""
+        self._inner.__exit__(type, value, traceback)
+
+    def __str__(self):
+        return f"<frame.EncoderWriterWrapper name={self._name}>"
+
+    def __repr__(self):
+        return f"<frame.EncoderWriterWrapper name={self._name}>"
+
+
+class EncoderWriterWrapper(IO[bytes]):
     """
     Wrapper that combines io.BufferedIOBase interface with
     FrameEncoderWriter functionality. This makes the LZ4
@@ -205,16 +231,18 @@ class EncoderWriterWrapper(io.BufferedIOBase):
     def __init__(
         self,
         filename: str,
+        mode: Literal["wb", "wb|lz4"],
         block_size: _frame.BlockSize = BlockSize.Auto,
         block_mode: _frame.BlockMode = BlockMode.Independent,
         block_checksums: Optional[bool] = None,
-        dict_id: Optional[bool] = None,
+        dict_id: Optional[int] = None,
         content_checksum: Optional[bool] = None,
         content_size: Optional[int] = None,
         legacy_frame: Optional[bool] = None,
     ) -> None:
         self._inner = _frame.FrameEncoderWriter(
             filename,
+            mode,
             block_size,
             block_mode,
             block_checksums,
@@ -223,6 +251,20 @@ class EncoderWriterWrapper(io.BufferedIOBase):
             content_size,
             legacy_frame,
         )
+        self._name = filename
+
+    @property
+    def mode(self) -> str:
+        return self._inner.mode
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def closed(self) -> bool:
+        """Returns True if the file is closed."""
+        return self._inner.closed
 
     # BufferedIOBase required methods
     def readable(self) -> bool:
@@ -258,7 +300,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
             ValueError: If the file is closed
             TypeError: If data is not a bytes-like object
         """
-        if self._inner.closed:
+        if self.closed:
             raise ValueError("I/O operation on closed file")
 
         # Convert to bytes if necessary
@@ -269,7 +311,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
                 f"Expected bytes-like object, got {type(data).__name__}"
             )
 
-        # Use the parent class's write method
+        # Use the inner writer's write method
         return self._inner.write(data)
 
     def writelines(
@@ -284,7 +326,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         Raises:
             ValueError: If the file is closed
         """
-        if self._inner.closed:
+        if self.closed:
             raise ValueError("I/O operation on closed file")
 
         for line in lines:
@@ -297,7 +339,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         Raises:
             ValueError: If the file is closed
         """
-        if self._inner.closed:
+        if self.closed:
             raise ValueError("I/O operation on closed file")
         self._inner.flush()
 
@@ -308,8 +350,29 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         Raises:
             IOError: If flushing fails during close
         """
-        if not self._inner.closed:
+        if not self.closed:
             self._inner.close()
+
+    def __enter__(self) -> Self:
+        """
+        Context manager entry — returns self.
+
+        Returns:
+            (`EncoderWriterWrapper`): The writer wrapper instance itself.
+        """
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:
+        """
+        Context manager exit — flushes and closes the writer.
+        """
+        self._inner.__exit__(type, value, traceback)
+
+    def __str__(self):
+        return f"<frame.DecoderReaderWrapper name={self._name}>"
+
+    def __repr__(self):
+        return f"<frame.DecoderReaderWrapper name={self._name}>"
 
 
 def open(
@@ -322,62 +385,66 @@ def open(
     content_checksum: Optional[bool] = None,
     content_size: Optional[int] = None,
     legacy_frame: Optional[bool] = None,
-) -> Union[DecoderReaderWrapper, EncoderWriterWrapper]:
+) -> IO[bytes]:
     """
     Returns a context manager for reading or writing lz4 frames.
 
     Example:
 
-    ```
+    ```python
     import os
     import safelz4
-
     from typing import Union
 
     MEGABYTE = 1024 * 1024
 
-    def chunk(filename : Union[os.PathLike, str], chunk_size : int = 1024):
+    def chunk(filename: Union[os.PathLike, str], chunk_size: int = 1024):
         with open(filename, "rb") as f:
             while content := f.read(chunk_size):
                 yield content
 
-    chunk_size = 1024
-    with safelz4.open("datafile.lz4", "wb") as file:
-            for buf in chunk("datafile.txt", MEGABYTE)
-                file.write(content)
+    # Writing LZ4 compressed data
+    with safelz4.lz4_open("datafile.lz4", "wb") as file:
+        for content in chunk("datafile.txt", MEGABYTE):
+            file.write(content)
     ```
 
     OR
 
-    ```
+    ```python
     import safelz4
 
+    # Reading LZ4 compressed data
     chunk_size = 1024
-    with safelz4.open("datafile.lz4", "rb") as file:
-        while content := f.read(chunk_size):
+    with safelz4.lz4_open("datafile.lz4", "rb") as file:
+        while content := file.read(chunk_size):
             print(content)
     ```
 
     OR
 
-    ```
+    ```python
     import safelz4
 
+    # Reading without context manager
     chunk_size = 1024
-    FILE = safelz4.open("datafile.lz4", "rb")
-
-    while content := FILE.read(chunk_size):
-        print(content)
-    FILE.close()
+    file = safelz4.lz4_open("datafile.lz4", "rb")
+    try:
+        while content := file.read(chunk_size):
+            print(content)
+    finally:
+        file.close()
     ```
     """
     if mode is None:
-        return DecoderReaderWrapper(filename, mode="rb")
-    elif mode in ("rb", "rb|lz4"):
+        mode = "rb"
+
+    if mode in ("rb", "rb|lz4"):
         return DecoderReaderWrapper(filename, mode)
     elif mode in ("wb", "wb|lz4"):
         return EncoderWriterWrapper(
             filename,
+            mode,
             block_size,
             block_mode,
             block_checksums,
@@ -387,4 +454,7 @@ def open(
             legacy_frame,
         )
     else:
-        raise ValueError(f"Unsupported mode: {mode}")
+        raise ValueError(
+            f"Unsupported mode: {mode}. Supported modes are: "
+            "'rb', 'rb|lz4', 'wb', 'wb|lz4'"
+        )

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -539,9 +539,10 @@ class DecoderReaderWrapper(io.BufferedIOBase):
 
     _inner: FrameDecoderReader
 
-    def __init__(self, filename: str) -> None: ...
+    def __init__(
+        self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
+    ) -> None: ...
 
-    # BufferedIOBase required methods
     def readable(self) -> bool:
         """Returns True since this is a readable stream."""
         ...
@@ -691,7 +692,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
 @overload
 def open(
     filename: Union[str, os.PathLike],
-    mode: Optional[Literal["rb", "rb|lz4", "wb", "wb|lz4"]] = None,
+    mode: Optional[Literal["r", "rb", "rb|lz4", "wb", "wb|lz4"]] = None,
 ) -> Union[DecoderReaderWrapper, EncoderWriterWrapper]: ...
 @overload
 def open(
@@ -708,5 +709,5 @@ def open(
 @overload
 def open(
     filename: Union[str, os.PathLike],
-    mode: Optional[Literal["rb", "rb|lz4"]] = None,
+    mode: Optional[Literal["r", "rb", "rb|lz4"]] = None,
 ) -> DecoderReaderWrapper: ...

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -1,6 +1,7 @@
 import os
 import io
-from typing import Optional, Union, Any, Literal, Final, List, IO, overload
+from typing import Optional, Union, Literal, Final, List, IO, overload
+from types import TracebackType
 
 try:
     from typing import Self
@@ -46,7 +47,8 @@ class BlockMode(Enum):
 
 class BlockSize(IntEnum):
     """
-    Block size for frame compression.
+    Size of individual compressed or uncompressed data
+    blocks within the frame.
 
     Attributes:
         Auto: Will detect optimal frame size based on the size of the first
@@ -346,11 +348,12 @@ class FrameDecoderReader:
             Path to the LZ4 frame file.
 
     Raises:
-        (`IOError`): If the file cannot be opened or memory-mapped.
-        (`ReadError`): If reading invalid memeory in the mmap.
-        (`HeaderError`): If reading file header fails.
-        (`DecompressionError`): If decompressing
-
+        (`IOError`):
+            Rasied if the file cannot be opened or memory-mapped.
+        (`ReadError`):
+            Raised if reading invalid memeory in the mmap.
+        (`HeaderError`):
+            Rasied if reading file header fails.
     """
 
     def __new__(self, filename: Union[os.PathLike, str]) -> Self: ...
@@ -428,6 +431,8 @@ class FrameDecoderReader:
             (`bytes`): A decompressed byte string of the requested size.
 
         Raises:
+            (`ValueError`):
+                Rasied if the file is closed
             (`ReadError`):
                 Raised if the input stream cannot be read or is incomplete.
             (`DecompressionError`):
@@ -452,7 +457,7 @@ class FrameDecoderReader:
         self,
         exc_type: Optional[type[BaseException]],
         exc_value: Optional[BaseException],
-        traceback: Optional[Any],
+        traceback: Optional[TracebackType],
     ) -> None:
         """
         Context manager exit
@@ -470,8 +475,11 @@ class FrameEncoderWriter:
             Frame parameters; uses defaults if None.
 
     Raises:
-        (`IOError`): If the file cannot be opened for writing.
-        (`CompressionError`): If writing something happens when into enocder.
+        (`LZ4Exception`):
+            Rasied when the file is closed.
+        (`CompressionError`):
+            Raised when a compression method is not supported or when
+            the data cannot be encoded properly.
     """
 
     def __new__(
@@ -548,7 +556,7 @@ class FrameEncoderWriter:
         self,
         exc_type: Optional[type[BaseException]],
         exc_value: Optional[BaseException],
-        traceback: Optional[Any],
+        traceback: Optional[TracebackType],
     ) -> None:
         """
         Context manager exit — flushes and closes the writer.
@@ -602,14 +610,26 @@ class WrappedDecoderReader(IO[bytes]):
         Read and return up to size bytes.
 
         Args:
-            size: Number of bytes to read. If -1 or None,
+            size (`int`, **optional**, default to -1):
+                Number of bytes to read. If -1 or None,
                 read all remaining data.
 
         Returns:
-            block read from the stream return sized bytes of said block
+            (`bytes`): block read from the stream return sized bytes of said
+                       block.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`):
+                Rasied if the file is closed
+            (`ReadError`):
+                Raised if the input stream cannot be read or is incomplete.
+            (`DecompressionError`):
+                Raised if the source buffer cannot be decompressed
+                into the destination buffer, typically due to corrupt or
+                malformed input.
+            (`LZ4Exception`):
+                Raised if a block checksum does not match the expected value,
+                indicating potential data corruption.
         """
         ...
     def readline(self, limit: int = -1) -> bytes:
@@ -617,16 +637,22 @@ class WrappedDecoderReader(IO[bytes]):
         Read and return one line from the stream.
 
         Args:
-            limit (int, **optional**, default: -1):
+            limit (`int`, **optional**, default: -1):
                 Maximum number of bytes to read.
                 If -1, read until newline or EOF.
 
         Returns:
-            bytes: A single line including the trailing newline character,
+            (`bytes`): A single line including the trailing newline character,
                 or empty bytes if EOF is reached.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`):
+                Rasied if the file is closed
+            (`ReadError`):
+                Raised when there is an issue reading the block.
+            (`DecompressionError`):
+                Raised decompression method is not supported or when
+                the data cannot be decoded properly.
         """
         ...
     def readlines(self, hint: int = -1) -> List[bytes]:
@@ -634,15 +660,28 @@ class WrappedDecoderReader(IO[bytes]):
         Read and return a list of lines from the stream.
 
         Args:
-            hint (int, optional): Approximate number of bytes to read.
-                                If -1, read all lines.
+            hint (`int`, **optional**, default: -1):
+                Approximate number of bytes to read.
+                If -1, read all lines.
 
         Returns:
-            List[bytes]: List of lines, each including trailing newline.
+            (`List[bytes]`): List of lines, each including trailing newline.
 
         Raises:
-            ValueError: If the file is closed.
+            (`ValueError`):
+                Raised if the file is closed
         """
+        ...
+    def __enter__(self) -> Self:
+        """Context manager entry"""
+        ...
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Context manager exit"""
         ...
     def __str__(self): ...
     def __repr__(self): ...
@@ -734,13 +773,17 @@ class WrappedEncoderWriter(IO[bytes]):
             (`IOError`): If flushing fails during close.
         """
         ...
-    def __enter__(self) -> Self: ...
+    def __enter__(self) -> Self:
+        """Context manager entry."""
+        ...
     def __exit__(
         self,
         exc_type: Optional[type[BaseException]],
         exc_value: Optional[BaseException],
-        traceback: Optional[Any],
-    ) -> None: ...
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Context manager exit."""
+        ...
     def __str__(self): ...
     def __repr__(self): ...
 

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -1,12 +1,12 @@
 import os
 import io
-from typing import Optional, Union, Any, Literal, Final, Iterable, IO, overload
+from typing import Optional, Union, Any, Literal, Final, List, IO, overload
 
 try:
-    from typing import Buffer, Self
+    from typing import Self
 except ImportError:
     # NOTE For Python < 3.12
-    from typing_extensions import Buffer, Self
+    from typing_extensions import Self
 
 from enum import IntEnum, Enum
 
@@ -353,8 +353,14 @@ class FrameDecoderReader:
 
     """
 
-    def __new__(self, filename: str) -> Self: ...
-    def mode(self) -> Literal["rb", "wb"]: ...
+    def __new__(self, filename: Union[os.PathLike, str]) -> Self: ...
+    @getattr
+    def closed(self) -> bool: ...
+    @getattr
+    def name(self) -> str: ...
+    @getattr
+    def mode(self) -> Literal["rb", "rb|lz4"]: ...
+    @getattr
     def offset(self) -> int:
         """
         Returns the offset after the LZ4 frame header.
@@ -363,6 +369,16 @@ class FrameDecoderReader:
             (`int`): Offset in bytes to the start of the first data block.
         """
         ...
+    @getattr
+    def current_block(self) -> int:
+        """
+        Return the amounf of blocks that has been read.
+
+        Returns:
+            (`int`): current block number.
+        """
+        ...
+    @getattr
     def content_size(self) -> Optional[int]:
         """
         Returns the content size specified in the LZ4 frame header.
@@ -371,6 +387,7 @@ class FrameDecoderReader:
             (`Optional[int]`): Content size if present, or None.
         """
         ...
+    @getattr
     def block_size(self) -> BlockSize:
         """
         Returns the block size used in the LZ4 frame.
@@ -379,6 +396,7 @@ class FrameDecoderReader:
             (`BlockSize`): Enum representing the block size.
         """
         ...
+    @getattr
     def block_checksum(self) -> bool:
         """
         Checks if block checksums are enabled for this frame.
@@ -387,6 +405,7 @@ class FrameDecoderReader:
             (`bool`): True if block checksums are enabled, False otherwise.
         """
         ...
+    @getattr
     def frame_info(self) -> FrameInfo:
         """
         Returns a copy of the parsed frame header.
@@ -421,11 +440,9 @@ class FrameDecoderReader:
         """
         ...
     def close(self) -> None: ...
-    @property
-    def closed(self) -> bool: ...
     def __enter__(self) -> Self:
         """
-        Context manager entry — returns self.
+        Context manager entry.
 
         Returns:
             (`FrameDecoderReader`): The reader instance itself.
@@ -459,7 +476,7 @@ class FrameEncoderWriter:
 
     def __new__(
         self,
-        filename: str,
+        filename: Union[os.PathLike, str],
         block_size: BlockSize = ...,
         block_mode: BlockMode = ...,
         block_checksums: Optional[bool] = ...,
@@ -468,6 +485,11 @@ class FrameEncoderWriter:
         content_size: Optional[int] = ...,
         legacy_frame: Optional[bool] = ...,
     ) -> Self: ...
+    @getattr
+    def closed(self) -> bool: ...
+    @getattr
+    def name(self) -> str: ...
+    @getattr
     def offset(self) -> int:
         """
         Returns the current write offset (total bytes written).
@@ -490,7 +512,7 @@ class FrameEncoderWriter:
             (`CompressionError`): If compression or writing fails.
         """
         ...
-    def mode(self) -> Literal["wb", "rb"]:
+    def mode(self) -> Literal["wb", "wb|lz4"]:
         """
         Return current mode
 
@@ -514,8 +536,6 @@ class FrameEncoderWriter:
             (`IOError`): If flushing fails during close.
         """
         ...
-    @property
-    def closed(self) -> bool: ...
     def __enter__(self) -> Self:
         """
         Context manager entry — returns self.
@@ -535,27 +555,36 @@ class FrameEncoderWriter:
         """
         ...
 
-class DecoderReaderWrapper(io.BufferedIOBase):
+class WrappedDecoderReader(IO[bytes]):
     """
-    Wrapper that combines io.BufferedIOBase interface with FrameDecoderReader
+    Wrapper that combines IO[bytes] interface with FrameDecoderReader
     functionality. This makes the LZ4 decoder compatible with Python's
     standard I/O system.
     """
 
     _inner: FrameDecoderReader
-    _name: str
 
     def __init__(
-        self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
+        self,
+        filename: Union[os.PathLike, str],
+        mode: Optional[Literal["rb", "rb|lz4"]] = None,
     ) -> None: ...
     @property
     def mode(self) -> str: ...
     @property
     def name(self) -> str: ...
     @property
-    def closed(self) -> bool:
-        """Returns True if the file is closed."""
-        ...
+    def closed(self) -> bool: ...
+    @property
+    def block_size(self) -> BlockSize: ...
+    @property
+    def content_sized(self) -> Optional[int]: ...
+    @property
+    def block_checksum(self) -> bool: ...
+    @property
+    def frame_info(self) -> FrameInfo: ...
+    @property
+    def current_block(self) -> int: ...
     def readable(self) -> bool:
         """Returns True since this is a readable stream."""
         ...
@@ -568,23 +597,7 @@ class DecoderReaderWrapper(io.BufferedIOBase):
     def tell(self) -> int:
         """Returns current position in block stream."""
         ...
-    def seek(self, pos: int, whence: int = ...) -> int:
-        """
-        Seek to position in the stream.
-
-        Args:
-            pos: Position to seek to
-            whence: How to interpret pos (SEEK_SET, SEEK_CUR, SEEK_END)
-
-        Returns:
-            New absolute position
-
-        Raises:
-            ValueError: If the file is closed
-            io.UnsupportedOperation: If seeking is not supported
-        """
-        ...
-    def read(self, size: Optional[int] = ...) -> bytes:
+    def read(self, n: int = -1) -> bytes:
         """
         Read and return up to size bytes.
 
@@ -599,40 +612,53 @@ class DecoderReaderWrapper(io.BufferedIOBase):
             ValueError: If the file is closed
         """
         ...
-    def read1(self, size: int = ...) -> bytes:
-        """Read and return up to size bytes from the stream."""
-        ...
-    def readinto(self, b: Buffer) -> Optional[int]:
+    def readline(self, limit: int = -1) -> bytes:
         """
-        Read data into a pre-allocated buffer.
+        Read and return one line from the stream.
 
         Args:
-            b: Buffer to read into (must support buffer protocol)
+            limit (int, **optional**, default: -1):
+                Maximum number of bytes to read.
+                If -1, read until newline or EOF.
 
         Returns:
-            Number of bytes read, or None if EOF
+            bytes: A single line including the trailing newline character,
+                or empty bytes if EOF is reached.
 
         Raises:
             ValueError: If the file is closed
         """
         ...
-    def readinto1(self, b: Buffer) -> int:
-        """Read data into buffer, single call to underlying raw stream."""
-        ...
+    def readlines(self, hint: int = -1) -> List[bytes]:
+        """
+        Read and return a list of lines from the stream.
 
-class EncoderWriterWrapper(io.BufferedIOBase):
+        Args:
+            hint (int, optional): Approximate number of bytes to read.
+                                If -1, read all lines.
+
+        Returns:
+            List[bytes]: List of lines, each including trailing newline.
+
+        Raises:
+            ValueError: If the file is closed.
+        """
+        ...
+    def __str__(self): ...
+    def __repr__(self): ...
+
+class WrappedEncoderWriter(IO[bytes]):
     """
-    Wrapper that combines io.BufferedIOBase interface with
+    Wrapper that combines IO[bytes] interface with
     FrameEncoderWriter functionality. This makes the LZ4
     encoder compatible with Python's standard I/O system.
     """
 
     _inner: FrameEncoderWriter
-    _name: str
 
     def __init__(
         self,
-        filename: str,
+        filename: Union[os.PathLike, str],
         block_size: BlockSize = ...,
         block_mode: BlockMode = ...,
         block_checksums: Optional[bool] = ...,
@@ -646,9 +672,11 @@ class EncoderWriterWrapper(io.BufferedIOBase):
     @property
     def name(self) -> str: ...
     @property
-    def closed(self) -> bool:
-        """Returns True if the file is closed."""
-        ...
+    def closed(self) -> bool: ...
+    @property
+    def offset(self) -> int: ...
+    @property
+    def frame_info(self) -> FrameInfo: ...
     def readable(self) -> bool:
         """Returns False since this is write-only."""
         ...
@@ -664,32 +692,30 @@ class EncoderWriterWrapper(io.BufferedIOBase):
     def tell(self) -> int:
         """Returns current position in the stream."""
         ...
-    def write(self, data: Union[bytes, bytearray, memoryview]) -> int:
+    def write(self, data: bytes) -> int:
         """
         Write data to the stream.
 
         Args:
-            data: Data to write (bytes-like object)
+            (`data`): Data to write.
 
         Returns:
-            Number of bytes written
+            (`int`): Number of bytes written.
 
         Raises:
-            ValueError: If the file is closed
-            TypeError: If data is not a bytes-like object
+            (`ValueError`): If the file is closed.
+            (`TypeError`): If data is not a bytes-like object.
         """
         ...
-    def writelines(
-        self, lines: Iterable[Union[bytes, bytearray, memoryview]]
-    ) -> None:
+    def writelines(self, lines: List[bytes]) -> None:
         """
         Write a list of bytes-like objects to the stream.
 
         Args:
-            lines: Iterable of bytes-like objects
+            lines (`List[bytes]`): Iterable of bytes-like objects.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`): If the file is closed.
         """
         ...
     def flush(self) -> None:
@@ -697,7 +723,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         Flush the internal buffer to disk.
 
         Raises:
-            ValueError: If the file is closed
+            (`ValueError`): If the file is closed.
         """
         ...
     def close(self) -> None:
@@ -705,20 +731,19 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         Close the stream and flush any remaining data.
 
         Raises:
-            IOError: If flushing fails during close
+            (`IOError`): If flushing fails during close.
         """
         ...
-    def __enter__(self) -> Self:
-        pass
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[Any],
+    ) -> None: ...
+    def __str__(self): ...
+    def __repr__(self): ...
 
-    def __exit__(self, type, value, traceback) -> None:
-        pass
-
-@overload
-def open(
-    filename: Union[str, os.PathLike],
-    mode: Optional[Literal["rb", "rb|lz4", "wb", "wb|lz4"]] = None,
-) -> io.BufferedIOBase: ...
 @overload
 def open(
     filename: Union[str, os.PathLike],
@@ -730,9 +755,9 @@ def open(
     content_checksum: Optional[bool] = None,
     content_size: Optional[int] = None,
     legacy_frame: Optional[bool] = None,
-) -> EncoderWriterWrapper: ...
+) -> WrappedEncoderWriter: ...
 @overload
 def open(
     filename: Union[str, os.PathLike],
     mode: Optional[Literal["rb", "rb|lz4"]] = None,
-) -> DecoderReaderWrapper: ...
+) -> WrappedDecoderReader: ...

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -1,7 +1,12 @@
 import os
 import io
 from typing import Optional, Union, Any, Literal, Final, Iterable, IO, overload
-from typing_extensions import Self, Buffer
+
+try:
+    from typing import Buffer, Self
+except ImportError:
+    # NOTE For Python < 3.12
+    from typing_extensions import Buffer, Self
 
 from enum import IntEnum, Enum
 
@@ -538,10 +543,19 @@ class DecoderReaderWrapper(io.BufferedIOBase):
     """
 
     _inner: FrameDecoderReader
+    _name: str
 
     def __init__(
         self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
     ) -> None: ...
+    @property
+    def mode(self) -> str: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def closed(self) -> bool:
+        """Returns True if the file is closed."""
+        ...
     def readable(self) -> bool:
         """Returns True since this is a readable stream."""
         ...
@@ -614,6 +628,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
     """
 
     _inner: FrameEncoderWriter
+    _name: str
 
     def __init__(
         self,
@@ -626,8 +641,14 @@ class EncoderWriterWrapper(io.BufferedIOBase):
         content_size: Optional[int] = ...,
         legacy_frame: Optional[bool] = ...,
     ) -> None: ...
-
-    # BufferedIOBase required methods
+    @property
+    def mode(self) -> str: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def closed(self) -> bool:
+        """Returns True if the file is closed."""
+        ...
     def readable(self) -> bool:
         """Returns False since this is write-only."""
         ...
@@ -687,12 +708,17 @@ class EncoderWriterWrapper(io.BufferedIOBase):
             IOError: If flushing fails during close
         """
         ...
+    def __enter__(self) -> Self:
+        pass
+
+    def __exit__(self, type, value, traceback) -> None:
+        pass
 
 @overload
 def open(
     filename: Union[str, os.PathLike],
-    mode: Optional[Literal["r", "rb", "rb|lz4", "wb", "wb|lz4"]] = None,
-) -> IO[bytes]: ...
+    mode: Optional[Literal["rb", "rb|lz4", "wb", "wb|lz4"]] = None,
+) -> io.BufferedIOBase: ...
 @overload
 def open(
     filename: Union[str, os.PathLike],
@@ -708,5 +734,5 @@ def open(
 @overload
 def open(
     filename: Union[str, os.PathLike],
-    mode: Optional[Literal["r", "rb", "rb|lz4"]] = None,
+    mode: Optional[Literal["rb", "rb|lz4"]] = None,
 ) -> DecoderReaderWrapper: ...

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -1,6 +1,6 @@
 import os
 import io
-from typing import Optional, Union, Any, Literal, Final, Iterable, overload
+from typing import Optional, Union, Any, Literal, Final, Iterable, IO, overload
 from typing_extensions import Self, Buffer
 
 from enum import IntEnum, Enum
@@ -542,7 +542,6 @@ class DecoderReaderWrapper(io.BufferedIOBase):
     def __init__(
         self, filename: str, mode: Optional[Literal["rb", "rb|lz4"]] = None
     ) -> None: ...
-
     def readable(self) -> bool:
         """Returns True since this is a readable stream."""
         ...
@@ -693,7 +692,7 @@ class EncoderWriterWrapper(io.BufferedIOBase):
 def open(
     filename: Union[str, os.PathLike],
     mode: Optional[Literal["r", "rb", "rb|lz4", "wb", "wb|lz4"]] = None,
-) -> Union[DecoderReaderWrapper, EncoderWriterWrapper]: ...
+) -> IO[bytes]: ...
 @overload
 def open(
     filename: Union[str, os.PathLike],

--- a/src/block.rs
+++ b/src/block.rs
@@ -65,8 +65,8 @@ fn compress_prepend_size<'py>(py: Python<'py>, input: &[u8]) -> PyResult<PyBound
 #[pyfunction]
 #[pyo3(signature = (input, output))]
 fn compress_into(input: &[u8], output: PyBound<'_, PyByteArray>) -> PyResult<usize> {
-    // NOTE: for possible safer practice it might be better 
-    //       to alloc mut vec, and return tha
+    //NOTE: for possible safer practice it might be better
+    //       to alloc mut vec, and return than using Pybound<'_, PyByteArray>.
     let buffer = unsafe { output.as_bytes_mut() };
     let size = lz4_flex::compress_into(input, buffer)
         .map_err(|e| LZ4BlockError::new_err(format!("{e}")))?;

--- a/src/block.rs
+++ b/src/block.rs
@@ -65,6 +65,8 @@ fn compress_prepend_size<'py>(py: Python<'py>, input: &[u8]) -> PyResult<PyBound
 #[pyfunction]
 #[pyo3(signature = (input, output))]
 fn compress_into(input: &[u8], output: PyBound<'_, PyByteArray>) -> PyResult<usize> {
+    // NOTE: for possible safer practice it might be better 
+    //       to alloc mut vec, and return tha
     let buffer = unsafe { output.as_bytes_mut() };
     let size = lz4_flex::compress_into(input, buffer)
         .map_err(|e| LZ4BlockError::new_err(format!("{e}")))?;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1221,6 +1221,14 @@ impl PyFrameDecoderReader {
         //       the mmap has allocated.
         self.close();
     }
+
+    fn __repr__(&self) -> String {
+        format!("<_frame.FrameDecoderReader name={:?}>", self.name,)
+    }
+
+    fn __str__(&self) -> String {
+        format!("<_frame.FrameDecoderReader name={:?}>", self.name,)
+    }
 }
 
 #[inline]
@@ -1367,6 +1375,14 @@ impl PyFrameEncoderWriter {
         _traceback: PyObject,
     ) -> PyResult<()> {
         self.close()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<_frame.FrameEncoderWriter name={:?}>", self.name,)
+    }
+
+    fn __str__(&self) -> String {
+        format!("<_frame.FrameEncoderWriter name={:?}>", self.name,)
     }
 }
 /// Check if a file is a valid LZ4 Frame file by reading its header

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -681,6 +681,7 @@ fn decompress_file(py: Python<'_>, filename: PathBuf) -> PyResult<PyBound<'_, Py
 pub enum LZ4FileMode {
     #[default]
     READ_BYTES,
+    READ_UNCOMPRESSED_BYTES,
     WRITE_BYTES,
 }
 
@@ -689,6 +690,7 @@ impl TryFrom<&str> for LZ4FileMode {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
+            "r" => Ok(LZ4FileMode::READ_UNCOMPRESSED_BYTES),
             "rb" | "rb|lz4" => Ok(LZ4FileMode::READ_BYTES),
             "wb" | "wb|lz4" => Ok(LZ4FileMode::WRITE_BYTES),
             m => Err(PyValueError::new_err(format!(
@@ -704,6 +706,7 @@ impl From<LZ4FileMode> for &str {
         match value {
             LZ4FileMode::READ_BYTES => "rb",
             LZ4FileMode::WRITE_BYTES => "wb",
+            LZ4FileMode::READ_UNCOMPRESSED_BYTES => "r",
         }
     }
 }
@@ -744,6 +747,8 @@ impl BlockInfo {
 #[pyclass]
 #[pyo3(name = "FrameDecoderReader")]
 struct PyFrameDecoderReader {
+    /// mode (read bytes un/compressed)
+    mode: LZ4FileMode,
     /// file header
     frame_info: PyFrameInfo,
     /// from file header the offset of the blocks
@@ -1002,8 +1007,18 @@ impl PyFrameDecoderReader {
 #[pymethods]
 impl PyFrameDecoderReader {
     #[new]
-    #[pyo3(signature = (filename))]
-    pub fn new(filename: PathBuf) -> PyResult<Self> {
+    #[pyo3(signature = (filename, mode = None))]
+    pub fn new(filename: PathBuf, mode: Option<&str>) -> PyResult<Self> {
+        let mode = match mode {
+            Some("rb" | "rb|lz4") => LZ4FileMode::READ_BYTES,
+            Some("r") => LZ4FileMode::READ_UNCOMPRESSED_BYTES,
+            None => LZ4FileMode::READ_BYTES,
+            Some(value) => {
+                return Err(PyValueError::new_err(format!(
+                    "{value} is not a valid mode."
+                )))
+            }
+        };
         let file = File::open(&filename).map_err(|e| {
             PyIOError::new_err(format!("Failed to open file {:?}: {}", filename, e))
         })?;
@@ -1047,6 +1062,7 @@ impl PyFrameDecoderReader {
         let dst = Vec::with_capacity(dst_size);
 
         Ok(Self {
+            mode,
             frame_info,
             offset,
             src,
@@ -1064,7 +1080,7 @@ impl PyFrameDecoderReader {
 
     /// Return mode of the reader.
     pub fn mode(&self) -> PyResult<&str> {
-        Ok("rb")
+        Ok(self.mode.into())
     }
 
     /// Returns the offset after the LZ4 frame header.
@@ -1102,6 +1118,7 @@ impl PyFrameDecoderReader {
         Ok(self.frame_info)
     }
 
+    /// check if the inner is closed.
     #[getter]
     fn closed(&self) -> PyResult<bool> {
         match self.inner {
@@ -1155,6 +1172,7 @@ impl PyFrameDecoderReader {
                     let read_len = std::cmp::min(self.dst_end - self.dst_start, buf.len());
                     let dst_read_end = self.dst_start + read_len;
                     buf[..read_len].copy_from_slice(&self.dst[self.dst_start..dst_read_end]);
+
                     self.dst_start = dst_read_end;
 
                     return Ok(Some(PyBytes::new(py, &buf[..read_len])));
@@ -1251,8 +1269,9 @@ impl PyFrameEncoderWriter {
         Ok(Self { offset: 0, inner })
     }
 
+    /// return file mode
     pub fn mode(&self) -> PyResult<&str> {
-        Ok("wb")
+        Ok(LZ4FileMode::WRITE_BYTES.into())
     }
 
     /// current total bytes written into writer.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -677,12 +677,10 @@ fn decompress_file(py: Python<'_>, filename: PathBuf) -> PyResult<PyBound<'_, Py
 
 /// IO File mode.
 #[allow(non_camel_case_types)]
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum LZ4FileMode {
-    #[default]
-    READ_BYTES,
-    READ_UNCOMPRESSED_BYTES,
-    WRITE_BYTES,
+    READ_BYTES(String),
+    WRITE_BYTES(String),
 }
 
 impl TryFrom<&str> for LZ4FileMode {
@@ -690,9 +688,10 @@ impl TryFrom<&str> for LZ4FileMode {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
-            "r" => Ok(LZ4FileMode::READ_UNCOMPRESSED_BYTES),
-            "rb" | "rb|lz4" => Ok(LZ4FileMode::READ_BYTES),
-            "wb" | "wb|lz4" => Ok(LZ4FileMode::WRITE_BYTES),
+            mode @ "rb" => Ok(LZ4FileMode::READ_BYTES(mode.into())),
+            mode @ "rb|lz4" => Ok(LZ4FileMode::READ_BYTES(mode.into())),
+            mode @ "wb" => Ok(LZ4FileMode::WRITE_BYTES(mode.into())),
+            mode @ "wb|lz4" => Ok(LZ4FileMode::WRITE_BYTES(mode.into())),
             m => Err(PyValueError::new_err(format!(
                 "{:?} is not a valid file mode",
                 m
@@ -701,12 +700,11 @@ impl TryFrom<&str> for LZ4FileMode {
     }
 }
 
-impl From<LZ4FileMode> for &str {
+impl From<LZ4FileMode> for String {
     fn from(value: LZ4FileMode) -> Self {
         match value {
-            LZ4FileMode::READ_BYTES => "rb",
-            LZ4FileMode::WRITE_BYTES => "wb",
-            LZ4FileMode::READ_UNCOMPRESSED_BYTES => "r",
+            LZ4FileMode::READ_BYTES(mode) => mode,
+            LZ4FileMode::WRITE_BYTES(mode) => mode,
         }
     }
 }
@@ -1009,15 +1007,9 @@ impl PyFrameDecoderReader {
     #[new]
     #[pyo3(signature = (filename, mode = None))]
     pub fn new(filename: PathBuf, mode: Option<&str>) -> PyResult<Self> {
-        let mode = match mode {
-            Some("rb" | "rb|lz4") => LZ4FileMode::READ_BYTES,
-            Some("r") => LZ4FileMode::READ_UNCOMPRESSED_BYTES,
-            None => LZ4FileMode::READ_BYTES,
-            Some(value) => {
-                return Err(PyValueError::new_err(format!(
-                    "{value} is not a valid mode."
-                )))
-            }
+        let mode: LZ4FileMode = match mode {
+            Some(m) => m.try_into()?,
+            None => LZ4FileMode::READ_BYTES(String::from("rb")),
         };
         let file = File::open(&filename).map_err(|e| {
             PyIOError::new_err(format!("Failed to open file {:?}: {}", filename, e))
@@ -1079,8 +1071,8 @@ impl PyFrameDecoderReader {
     }
 
     /// Return mode of the reader.
-    pub fn mode(&self) -> PyResult<&str> {
-        Ok(self.mode.into())
+    pub fn mode(&self) -> PyResult<String> {
+        Ok(self.mode.clone().into())
     }
 
     /// Returns the offset after the LZ4 frame header.
@@ -1122,8 +1114,8 @@ impl PyFrameDecoderReader {
     #[getter]
     fn closed(&self) -> PyResult<bool> {
         match self.inner {
-            Some(_) => Ok(false),
             None => Ok(true),
+            _ => Ok(false),
         }
     }
 
@@ -1220,6 +1212,7 @@ fn vec_resize_and_get_mut(v: &mut Vec<u8>, start: usize, end: usize) -> &mut [u8
 #[pyo3(name = "FrameEncoderWriter")]
 struct PyFrameEncoderWriter {
     offset: usize,
+    mode: LZ4FileMode,
     inner: Option<FrameEncoder<BufWriter<File>>>,
 }
 
@@ -1236,10 +1229,11 @@ impl PyFrameEncoderWriter {
 #[pymethods]
 impl PyFrameEncoderWriter {
     #[new]
-    #[pyo3(signature = (filename, block_size, block_mode, block_checksums = None, dict_id = None, content_checksum = None, content_size = None, legacy_frame = None))]
+    #[pyo3(signature = (filename, mode, block_size, block_mode, block_checksums = None, dict_id = None, content_checksum = None, content_size = None, legacy_frame = None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         filename: PathBuf,
+        mode: Option<&str>,
         block_size: PyBlockSize,
         block_mode: PyBlockMode,
         block_checksums: Option<bool>,
@@ -1266,12 +1260,22 @@ impl PyFrameEncoderWriter {
         .into();
         let inner = Some(FrameEncoder::with_frame_info(frame_info, wtr));
 
-        Ok(Self { offset: 0, inner })
+        let mode = match mode {
+            Some(value) => value.try_into()?,
+            None => LZ4FileMode::WRITE_BYTES(String::from("wb")),
+        };
+
+        Ok(Self {
+            offset: 0,
+            inner,
+            mode,
+        })
     }
 
     /// return file mode
-    pub fn mode(&self) -> PyResult<&str> {
-        Ok(LZ4FileMode::WRITE_BYTES.into())
+    #[getter]
+    pub fn mode(&self) -> PyResult<String> {
+        Ok(self.mode.clone().into())
     }
 
     /// current total bytes written into writer.
@@ -1304,8 +1308,8 @@ impl PyFrameEncoderWriter {
     #[getter]
     fn closed(&self) -> PyResult<bool> {
         match self.inner {
-            Some(_) => Ok(false),
             None => Ok(true),
+            _ => Ok(false),
         }
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -745,6 +745,8 @@ impl BlockInfo {
 #[pyclass]
 #[pyo3(name = "FrameDecoderReader")]
 struct PyFrameDecoderReader {
+    /// name of the file.
+    name: PathBuf,
     /// mode (read bytes un/compressed)
     mode: LZ4FileMode,
     /// file header
@@ -1008,7 +1010,7 @@ impl PyFrameDecoderReader {
     #[pyo3(signature = (filename, mode = None))]
     pub fn new(filename: PathBuf, mode: Option<&str>) -> PyResult<Self> {
         let mode: LZ4FileMode = match mode {
-            Some(m) => m.try_into()?,
+            Some(value) => value.try_into()?,
             None => LZ4FileMode::READ_BYTES(String::from("rb")),
         };
         let file = File::open(&filename).map_err(|e| {
@@ -1054,6 +1056,7 @@ impl PyFrameDecoderReader {
         let dst = Vec::with_capacity(dst_size);
 
         Ok(Self {
+            name: filename,
             mode,
             frame_info,
             offset,
@@ -1070,44 +1073,16 @@ impl PyFrameDecoderReader {
         })
     }
 
+    #[getter]
+    /// return the name of the file
+    pub fn name(&self) -> PyResult<PathBuf> {
+        Ok(self.name.clone())
+    }
+
     /// Return mode of the reader.
+    #[getter]
     pub fn mode(&self) -> PyResult<String> {
         Ok(self.mode.clone().into())
-    }
-
-    /// Returns the offset after the LZ4 frame header.
-    /// Returns:
-    ///     (`int`): Offset in bytes to the start of the first data block.
-    pub fn offset(&self) -> PyResult<usize> {
-        Ok(self.offset)
-    }
-
-    /// Returns the content size specified in the LZ4 frame header.
-    /// Returns:
-    ///     (`Optional[int]`): Content size if present, or None.
-    pub fn content_size(&self) -> PyResult<Option<u64>> {
-        self.frame_info.get_content_size()
-    }
-
-    /// Returns the block size used in the LZ4 frame.
-    /// Returns:
-    ///     (`BlockSize`): Enum representing the block size.
-    pub fn block_size(&self) -> PyResult<PyBlockSize> {
-        self.frame_info.get_block_size()
-    }
-
-    /// Checks if block checksums are enabled for this frame.
-    /// Returns:
-    ///     (`bool`): True if block checksums are enabled, False otherwise.
-    pub fn block_checksum(&self) -> PyResult<bool> {
-        self.frame_info.get_block_checksums()
-    }
-
-    /// Returns a copy of the parsed frame header.
-    /// Returns:
-    ///     (`FrameInfo`): Frame header metadata object.
-    pub fn frame_info(&self) -> PyResult<PyFrameInfo> {
-        Ok(self.frame_info)
     }
 
     /// check if the inner is closed.
@@ -1117,6 +1092,54 @@ impl PyFrameDecoderReader {
             None => Ok(true),
             _ => Ok(false),
         }
+    }
+
+    /// Returns the offset after the LZ4 frame header.
+    /// Returns:
+    ///     (`int`): Offset in bytes to the start of the first data block.
+    #[getter]
+    pub fn offset(&self) -> PyResult<usize> {
+        Ok(self.offset)
+    }
+
+    /// Return the amounf of blocks that has been read.
+    /// Returns:
+    ///     (`int`): current block number.
+    #[getter]
+    pub fn current_block(&self) -> PyResult<usize> {
+        Ok(self.current_block)
+    }
+
+    /// Returns the content size specified in the LZ4 frame header.
+    /// Returns:
+    ///     (`Optional[int]`): Content size if present, or None.
+    #[getter]
+    pub fn content_size(&self) -> PyResult<Option<u64>> {
+        self.frame_info.get_content_size()
+    }
+
+    /// Returns the block size used in the LZ4 frame.
+    /// Returns:
+    ///     (`BlockSize`): Enum representing the block size.
+    #[getter]
+    pub fn block_size(&self) -> PyResult<PyBlockSize> {
+        self.frame_info.get_block_size()
+    }
+
+    /// Checks if block checksums are enabled for this frame.
+    /// Returns:
+    ///     (`bool`): True if block checksums are enabled, False otherwise.
+    #[getter]
+    pub fn block_checksum(&self) -> PyResult<bool> {
+        self.frame_info.get_block_checksums()
+    }
+
+    /// Returns a copy of the parsed frame header.
+    /// Returns:
+    ///     (`FrameInfo`): Frame header metadata object.
+    #[getter]
+    pub fn frame_info(&self) -> PyResult<PyFrameInfo> {
+        Ok(self.frame_info)
     }
 
     /// Reads and returns a decompressed block of the specified size.
@@ -1211,8 +1234,13 @@ fn vec_resize_and_get_mut(v: &mut Vec<u8>, start: usize, end: usize) -> &mut [u8
 #[pyclass]
 #[pyo3(name = "FrameEncoderWriter")]
 struct PyFrameEncoderWriter {
-    offset: usize,
+    /// name of the file.
+    name: PathBuf,
+    /// cached mode type.
     mode: LZ4FileMode,
+    /// writer offset counter.
+    offset: usize,
+    /// underlying Frame Encoder over file buffer writer.
     inner: Option<FrameEncoder<BufWriter<File>>>,
 }
 
@@ -1266,24 +1294,33 @@ impl PyFrameEncoderWriter {
         };
 
         Ok(Self {
+            name: filename,
+            mode,
             offset: 0,
             inner,
-            mode,
         })
     }
 
-    /// return file mode
+    #[getter]
+    /// return the name of the file
+    pub fn name(&self) -> PyResult<PathBuf> {
+        Ok(self.name.clone())
+    }
+
+    /// Return mode of the writer.
     #[getter]
     pub fn mode(&self) -> PyResult<String> {
         Ok(self.mode.clone().into())
     }
 
     /// current total bytes written into writer.
+    #[getter]
     fn offset(&self) -> PyResult<usize> {
         Ok(self.offset)
     }
 
     /// current frame info
+    #[getter]
     fn frame_info(&mut self) -> PyResult<PyFrameInfo> {
         Ok(self.inner()?.frame_info().clone().into())
     }

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -304,7 +304,7 @@ def test_read_write_context_check_info():
         assert block_size == BlockSize.Auto
         written = f.write(original)
         # NOTE: The Auto block size should of changed.
-        assert block_size != BlockSize.Auto
+        assert f.frame_info.block_size != BlockSize.Auto
         assert written <= len(original)
         expected = f.frame_info
         f.close()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -12,6 +12,7 @@ from safelz4 import (
     decompress_file,
 )
 from safelz4.frame import compress_with_info
+from typing import IO
 import tempfile
 
 # Error handling and edge cases
@@ -293,18 +294,53 @@ def test_closed_exeption_throw():
 
 
 def test_read_write_context_check_info():
+    """Test properties/functions of wrapper Encoder/Decoder"""
+    original = b"Idempotency test data" * 10000
+    with tempfile.NamedTemporaryFile() as tmp:
+        f = safelz4.open(tmp.name, "wb")
+        # NOTE: Since We don't declare a block size default to AUTO.
+        #       though this should change when we write to the object
+        block_size = f.frame_info.block_size
+        assert block_size == BlockSize.Auto
+        written = f.write(original)
+        # NOTE: The Auto block size should of changed.
+        assert block_size != BlockSize.Auto
+        assert written <= len(original)
+        expected = f.frame_info
+        f.close()
+
+        # Read Compressed Bytes
+        o = safelz4.open(tmp.name, "rb")
+        # Info
+        assert o.frame_info == expected
+        assert o.current_block == 0
+        # NOTE: 210_000 bytes < 256_000 bytes
+        assert o.block_size == BlockSize.Max256KB
+        assert o.block_checksum == False
+        assert o.content_size == None
+        assert o.mode == "rb"
+        assert o.name == tmp.name
+
+        # IO generic call check
+        assert o.readable() == True  # not closed so should be readable
+        assert o.writable() == False  # should be false always
+        assert original == o.read(-1)  # read all bytes
+        assert o.read(-1) == b""  # empty bytes
+        max_block = math.ceil(len(original) / o.block_size.get_size())
+        assert max_block == o.current_block
+        o.close()
+
+
+def test_instance_IO_typeing():
+    """Test that safelz4 is an instance of it's inhertance class IO"""
     original = b"Idempotency test data" * 10000
     with tempfile.NamedTemporaryFile() as tmp:
         f = safelz4.open(tmp.name, "wb")
         f.write(original)
-        expected = f.frame_info
+        assert isinstance(f, IO)
         f.close()
         o = safelz4.open(tmp.name, "rb")
-        assert o.frame_info == expected
-        assert o.current_block == 0
-        assert original == o.read(-1)
-        max_block = math.ceil(len(original) / o.block_size.get_size())
-        assert max_block == o.current_block
+        assert isinstance(o, IO)
         o.close()
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,4 +1,5 @@
 import os
+import math
 import pytest
 import safelz4
 from safelz4 import (
@@ -277,15 +278,34 @@ def test_file_permission_errors():
 def test_closed_exeption_throw():
 
     with tempfile.NamedTemporaryFile() as tmp:
-        # Make file read-only
-        # This should fail when trying to write
         f = safelz4.open(tmp.name, "wb")
         f.write(b"test")
         assert f.closed == False
         f.close()
         assert f.closed == True
         with pytest.raises((ValueError)):
+            # NOTE: Memory writer
+            # within the rust binding, though in this case
+            # since where using the wrapped object is
+            # is a check that just checks if the file is
+            # closed. i.e None
             f.write(b"hello world")
+
+
+def test_read_write_context_check_info():
+    original = b"Idempotency test data" * 10000
+    with tempfile.NamedTemporaryFile() as tmp:
+        f = safelz4.open(tmp.name, "wb")
+        f.write(original)
+        expected = f.frame_info
+        f.close()
+        o = safelz4.open(tmp.name, "rb")
+        assert o.frame_info == expected
+        assert o.current_block == 0
+        assert original == o.read(-1)
+        max_block = math.ceil(len(original) / o.block_size.get_size())
+        assert max_block == o.current_block
+        o.close()
 
 
 def test_roundtrip_idempotency():

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -224,7 +224,6 @@ def test_concurrent_compression():
     assert all(results), "Not all concurrent operations succeeded"
 
 
-# Input validation
 def test_frame_info_invalid_parameters():
     """Test FrameInfo with invalid parameters"""
     # This depends on your implementation - adjust as needed
@@ -273,6 +272,20 @@ def test_file_permission_errors():
         finally:
             # Restore permissions for cleanup
             os.chmod(tmp.name, 0o644)
+
+
+def test_closed_exeption_throw():
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        # Make file read-only
+        # This should fail when trying to write
+        f = safelz4.open(tmp.name, "wb")
+        f.write(b"test")
+        assert f.closed == False
+        f.close()
+        assert f.closed == True
+        with pytest.raises((ValueError)):
+            f.write(b"hello world")
 
 
 def test_roundtrip_idempotency():


### PR DESCRIPTION
## 📋 Description
use IO[bytes] from typing as the base class for encoder/decoder wrappers for simpler typing

## 🧪 Testing

Added a small test that check if the file is properly closed.
```py
def test_closed_exeption_throw():

    with tempfile.NamedTemporaryFile() as tmp:
        # Make file read-only
        # This should fail when trying to write
        f = safelz4.open(tmp.name, "wb")
        f.write(b"test")
        assert f.closed == False
        f.close()
        assert f.closed == True
        with pytest.raises((ValueError)):
            f.write(b"hello world")
```

