### PR TITLE
feat: add basic lz4 command line interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "safelz4_py"
-version = "0.0.2"
+version = "0.0.5"
 edition = "2021"
 description = """
-High-performance Rust bindings to the LZ4 compression algorithm. Ideal for fast, lightweight data compression in systems programming, file formats, or network protocols. 
+High-performance Rust bindings to the LZ4 compression algorithm. Ideal for fast, lightweight data compression in systems programming, file formats, or network protocols.
 """
 exclude = ["benches/*", "tests/*", "fuzz/*", "examples/*"]
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <!-- Uncomment when release to pypi -->
     <a href="https://pypi.org/project/safelz4/"><img alt="PyPI" src="https://img.shields.io/pypi/v/safelz4"></a>
     <a href="https://pypi.org/project/safelz4/"><img alt="Python Version" src="https://img.shields.io/pypi/pyversions/safelz4?logo=python"></a>
+    <a href="https://pepy.tech/projects/safelz4"><img src="https://static.pepy.tech/personalized-badge/safelz4?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="PyPI Downloads"></a>
 </p>
 
 Python bindings for [lz4_flex](https://github.com/PSeitz/lz4_flex), the fastest pure-Rust implementation of the LZ4 compression algorithm.
@@ -143,7 +144,7 @@ Benchmark results are available in the `benches` folder. We evaluated performanc
 | ctx_decompression_writer_xml_collection.xml       | 1.99 ms        | 3.97 ms: 2.00x slower |
 | **Geometric mean**                              | **(ref)**      | **2.03x slower**      |
 
-### Full byte availability Run(s) 
+### Full byte availability Run(s)
 | `frame.compress` Benchmark                           | safelz4 | lz4                 |
 |-------------------------------------|-----------|----------------------|
 | compression_compression_1k.txt       | 829 ns    | 839 ns: 1.01x slower |
@@ -181,7 +182,7 @@ Special thanks also to the maintainers of the [lz4_flex](https://github.com/PSei
 
 `LZ4` implementations, including:
 
-| Python Library    | Build Status | Version | Licence | 
+| Python Library    | Build Status | Version | Licence |
 | -------- | ------- | ------- | ------- |
 | [python-lz4](https://github.com/python-lz4/python-lz4) | [![Build Status](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml/badge.svg)](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml)| ![](https://img.shields.io/pypi/v/lz4) | ![PyPI - License](https://img.shields.io/pypi/l/lz4)
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Special thanks also to the maintainers of the [lz4_flex](https://github.com/PSei
 
 | Python Library    | Build Status | Version | Licence | 
 | -------- | ------- | ------- | ------- |
-| [python-lz4](https://github.com/python-lz4/python-lz4) | ![](https://pypi-camo.freetls.fastly.net/6d3d73bb6f61ccadc08c11e3dcee01e847fc768e/68747470733a2f2f6769746875622e636f6d2f707974686f6e2d6c7a342f707974686f6e2d6c7a342f616374696f6e732f776f726b666c6f77732f6275696c645f646973742e796d6c2f62616467652e737667)    | ![](https://img.shields.io/pypi/v/lz4) | ![PyPI - License](https://img.shields.io/pypi/l/lz4)
+| [python-lz4](https://github.com/python-lz4/python-lz4) | [![Build Status](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml/badge.svg)](https://github.com/python-lz4/python-lz4/actions/workflows/build_dist.yml)| ![](https://img.shields.io/pypi/v/lz4) | ![PyPI - License](https://img.shields.io/pypi/l/lz4)
 
 
 

--- a/py/safelz4/__init__.py
+++ b/py/safelz4/__init__.py
@@ -23,6 +23,8 @@ Architecture:
     * error - Comprehensive exception hierarchy for precise error handling
 
 Example Usage:
+```
+
     >>> import safelz4
     >>>
     >>> # Frame-level compression
@@ -39,6 +41,7 @@ Example Usage:
     ...     while chunk := compressed_file.read(8192):
     ...         process_data(chunk)
 
+```
 Performance Characteristics:
     SafeLZ4 is optimized for scenarios requiring fast compression/decompression
     with moderate compression ratios. It excels in real-time data processing,

--- a/py/safelz4/__init__.py
+++ b/py/safelz4/__init__.py
@@ -33,8 +33,11 @@ Example Usage:
     >>> original = safelz4.decompress(compressed)
     >>>
     >>> # File operations with automatic format detection
-    >>> safelz4.compress_into_file("large_dataset.json", "dataset.lz4")
-    >>> safelz4.decompress_file("dataset.lz4", "restored_dataset.json")
+    >>> with open("datafile.txt", "rb") as file:
+    ...     buffer = file.read(-1)
+    ...     safelz4.compress_into_file("datafile.lz4", buffer)
+    >>>
+    >>> output = safelz4.decompress_file("dataset.lz4")
     >>>
     >>> # Stream processing for large files
     >>> with safelz4.open("archive.lz4", "rb") as compressed_file:

--- a/py/safelz4/__init__.py
+++ b/py/safelz4/__init__.py
@@ -1,3 +1,51 @@
+"""
+SafeLZ4: High-Performance LZ4 Compression Library for Python
+
+SafeLZ4 is a Python library that provides secure and efficient
+bindings to the LZ4 compression algorithm. Built with Rust for optimal
+performance and memory safety, it offers comprehensive compression solutions
+for enterprise and high-throughput applications.
+
+Overview:
+    SafeLZ4 implements the LZ4 lossless compression algorithm with
+    enhanced safety mechanisms and robust error handling. The library
+    supports both low-level block operations and high-level frame
+    operations, enabling developers to choose the appropriate
+    abstraction level for their use case.
+
+Architecture:
+    The library is structured into three primary modules:
+
+    * block - Direct block-level compression primitives for maximum performance
+              and control over compression parameters
+    * frame - Standards-compliant LZ4 frame format implementation with metadata
+              support and streaming capabilities
+    * error - Comprehensive exception hierarchy for precise error handling
+
+Example Usage:
+    >>> import safelz4
+    >>>
+    >>> # Frame-level compression
+    >>> data = b"Sample data for compression" * 1000
+    >>> compressed = safelz4.compress(data)
+    >>> original = safelz4.decompress(compressed)
+    >>>
+    >>> # File operations with automatic format detection
+    >>> safelz4.compress_into_file("large_dataset.json", "dataset.lz4")
+    >>> safelz4.decompress_file("dataset.lz4", "restored_dataset.json")
+    >>>
+    >>> # Stream processing for large files
+    >>> with safelz4.open("archive.lz4", "rb") as compressed_file:
+    ...     while chunk := compressed_file.read(8192):
+    ...         process_data(chunk)
+
+Performance Characteristics:
+    SafeLZ4 is optimized for scenarios requiring fast compression/decompression
+    with moderate compression ratios. It excels in real-time data processing,
+    network communication, and storage applications where speed is prioritized
+    over maximum compression efficiency.
+"""
+
 from ._safelz4_rs import __version__
 import safelz4.block as block
 import safelz4.frame as frame

--- a/py/safelz4/__init__.py
+++ b/py/safelz4/__init__.py
@@ -69,6 +69,7 @@ __all__ = [
     "__version__",
     "block",
     "frame",
+    "error",
     "BlockMode",
     "BlockSize",
     "FrameInfo",

--- a/py/safelz4/__main__.py
+++ b/py/safelz4/__main__.py
@@ -1,4 +1,11 @@
 from safelz4._cli._entry import main
 
+
+def run():
+    import sys as _sys
+
+    _sys.exit(main())
+
+
 if __name__ == "__main__":
-    main()
+    run()

--- a/py/safelz4/__main__.py
+++ b/py/safelz4/__main__.py
@@ -1,2 +1,4 @@
+from safelz4._cli._entry import main
+
 if __name__ == "__main__":
-    pass
+    main()

--- a/py/safelz4/_cli/__init__.py
+++ b/py/safelz4/_cli/__init__.py
@@ -1,3 +1,3 @@
-from ._entry import main
+from safelz4._cli._entry import main
 
 __all__ = ["main"]

--- a/py/safelz4/_cli/__init__.py
+++ b/py/safelz4/_cli/__init__.py
@@ -1,0 +1,3 @@
+from ._entry import main
+
+__all__ = ["main"]

--- a/py/safelz4/_cli/_entry.py
+++ b/py/safelz4/_cli/_entry.py
@@ -46,11 +46,16 @@ def _parse_argument() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="slz4",
         description="LZ4 compression and decompression utility",
-        epilog="Examples:\n"
-        "  %(prog)s -cb input.txt output.lz4\n"
-        "  %(prog)s -df output.lz4 output.txt\n"
-        "  %(prog)s -cf dickens.txy dickens.lz4\n"
-        "cat input.txt |  %(prog)s -cfo input.txt.lz4",
+        epilog="Block Examples:\n"
+        "  %(prog)s -cboi output input.txt\n"
+        "  %(prog)s -dboi input-copy.txt output\n"
+        "  cat input.txt | %(prog)s -cbi\n"
+        "  cat output | %(prog)s -dbi\b"
+        "  echo 'hello world' | %(prog)s -cb | %(prog)s -db --size $(echo 'hello world' | wc -c)\n\n"
+        "Frame Examples:\n"
+        "  %(prog)s -df dickens.lz4 -o output.txt\n"
+        "  %(prog)s -cf dickens.txt -o dickens.lz4\n"
+        "  cat input.txt | %(prog)s -cfo input.txt.lz4",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
@@ -170,6 +175,13 @@ def main():
 
         if args.block:
             buffer = args.infile.read(-1)
+            if len(buffer) > 1024 * 1024 * 8:
+                print(
+                    "Warning: Input is larger than 8MB.\n"
+                    "Consider using frame compression for better"
+                    " performance.",
+                    file=_sys.stderr,
+                )
             output = None
             if mode == "c":
                 if args.include_size:
@@ -185,7 +197,7 @@ def main():
             args.output.write(output)
         else:
             # Check if using stdin (not stdout)
-            if args.infile.name == "<stdin>":
+            if args.output is _sys.stdout.buffer:
                 buffer = args.infile.read(-1)
                 output = None
                 if mode == "c":
@@ -196,54 +208,54 @@ def main():
                 # write out to BinaryIO
                 args.output.write(output)
             else:
-                file = None
-                if mode == "c":
-                    # Compression: read from input file, write to compressed
-                    # file.
-                    block_size = args.block_size
-                    block_mode = (
-                        safelz4.BlockMode.Independent
-                        if args.block_independence
-                        else safelz4.BlockMode.Linked
-                    )
-                    block_checksums = (
-                        args.block_checksums
-                    )  # Fixed variable name
-                    content_checksum = args.content_checksum
-                    legacy_frame = args.legacy_frame
+                try:
+                    file = None
+                    if mode == "c":
+                        # Compression: read from input file, write to compressed
+                        # file.
+                        block_size = args.block_size
+                        block_mode = (
+                            safelz4.BlockMode.Independent
+                            if args.block_independence
+                            else safelz4.BlockMode.Linked
+                        )
+                        block_checksums = args.block_checksums
+                        content_checksum = args.content_checksum
+                        legacy_frame = args.legacy_frame
 
-                    file = safelz4.open(
-                        args.output.name,  # Fixed variable name
-                        mode="wb",
-                        block_size=block_size,
-                        block_mode=block_mode,
-                        block_checksums=block_checksums,
-                        content_checksum=content_checksum,
-                        legacy_frame=legacy_frame,
-                    )
-                    if args.buffer_size == -1:
-                        buffer = args.infile.read(-1)
-                        file.write(buffer)
+                        file = safelz4.open(
+                            args.output.name,
+                            mode="wb",
+                            block_size=block_size,
+                            block_mode=block_mode,
+                            block_checksums=block_checksums,
+                            content_checksum=content_checksum,
+                            legacy_frame=legacy_frame,
+                        )
+                        if args.buffer_size == -1:
+                            buffer = args.infile.read(-1)
+                            file.write(buffer)
+                        else:
+                            while content := args.infile.read(args.buffer_size):
+                                file.write(content)
                     else:
-                        while content := args.infile.read(args.buffer_size):
-                            file.write(content)
-                else:
-                    # Decompression: read from compressed file, write to output
-                    file = safelz4.open(args.infile.name, mode="rb")
-                    if args.buffer_size == -1:
-                        buffer = file.read(-1)
-                        args.output.write(buffer)
-                    else:
-                        while content := file.read(args.buffer_size):
-                            args.output.write(content)  # Fixed variable name
+                        # Decompression: read from compressed file, write to output
+                        file = safelz4.open(args.infile.name, mode="rb")
+                        if args.buffer_size == -1:
+                            buffer = file.read(-1)
+                            args.output.write(buffer)
+                        else:
+                            while content := file.read(args.buffer_size):
+                                args.output.write(
+                                    content
+                                )
 
-                # close file
-                file.close()
-                args.infile.close()
-                args.output.close()
+                finally:
+                    # always close file.
+                    file.close()
 
         # Handle file extension/suffix logic
-        if args.output.name != "<stdout>":  # Fixed condition
+        if args.output != _sys.stdout.buffer:
             output_file, ext = _os.path.splitext(args.output.name)
             suffix = args.suffix
 
@@ -253,10 +265,10 @@ def main():
                 _os.replace(args.output.name, new_name)
 
         # Remove input file if dispose flag is set
-        if args.dispose and args.infile.name != "<stdin>":
+        if args.dispose and args.infile != _sys.stdin.buffer:
             _os.remove(args.infile.name)
     except Exception as e:
-        print(e)
+        print(e, file=_sys.stderr)
         return 1
 
 

--- a/py/safelz4/_cli/_entry.py
+++ b/py/safelz4/_cli/_entry.py
@@ -33,12 +33,13 @@ def simple_blocksize_type(value: str) -> safelz4.BlockSize:
 def _handle_args_mode(
     compression: bool, decompression: bool
 ) -> Literal["c", "d"]:
+    """convert boolean logic to Literal char."""
     if compression:
         return "c"
     elif decompression:
         return "d"
     else:
-        raise ValueError("no other mode is supported.")
+        raise ValueError("No other mode is supported.")
 
 
 def _parse_argument() -> argparse.Namespace:
@@ -51,7 +52,8 @@ def _parse_argument() -> argparse.Namespace:
         "  %(prog)s -dboi input-copy.txt output\n"
         "  cat input.txt | %(prog)s -cbi\n"
         "  cat output | %(prog)s -dbi\b"
-        "  echo 'hello world' | %(prog)s -cb | %(prog)s -db --size $(echo 'hello world' | wc -c)\n\n"
+        "  echo 'hello world' | %(prog)s -cb |"
+        "  %(prog)s -db --size $(echo 'hello world' | wc -c)\n\n"
         "Frame Examples:\n"
         "  %(prog)s -df dickens.lz4 -o output.txt\n"
         "  %(prog)s -cf dickens.txt -o dickens.lz4\n"
@@ -167,110 +169,118 @@ def _parse_argument() -> argparse.Namespace:
     return args
 
 
-def main():
+def main() -> int:
     """entry cli function"""
-    try:
-        args = _parse_argument()
-        mode = _handle_args_mode(args.compress, args.decompress)
+    args = _parse_argument()
+    mode = _handle_args_mode(args.compress, args.decompress)
 
+    # Check for invalid combinations
+    if args.block and args.include_size and mode == "d" and args.size != 0:
+        print(
+            "Warning: '--size' is not needed when '--include-size' "
+            "is used for block decompression.",
+            file=_sys.stderr,
+        )
+
+    try:
+        # Block mode
         if args.block:
-            buffer = args.infile.read(-1)
-            if len(buffer) > 1024 * 1024 * 8:
-                print(
-                    "Warning: Input is larger than 8MB.\n"
-                    "Consider using frame compression for better"
-                    " performance.",
-                    file=_sys.stderr,
-                )
+            buffer = args.infile.read()
+            if not buffer:
+                raise ValueError("Input data is empty or could not be read.")
+
             output = None
             if mode == "c":
                 if args.include_size:
                     output = safelz4.block.compress_prepend_size(buffer)
                 else:
                     output = safelz4.block.compress(buffer)
-            else:
+            else:  # Decompression
                 if args.include_size:
                     output = safelz4.block.decompress_size_prepended(buffer)
                 else:
+                    if args.size == 0:
+                        raise ValueError(
+                            "The '--size' argument is required for block "
+                            "decompression when '--include-size' is"
+                            " not specified."
+                        )
                     output = safelz4.block.decompress(buffer, args.size)
 
             args.output.write(output)
+
+        # Frame mode
         else:
-            # Check if using stdin (not stdout)
-            if args.output is _sys.stdout.buffer:
-                buffer = args.infile.read(-1)
+            if args.buffer_size == -1:
+                # One-shot operation for efficiency
+                buffer = args.infile.read()
+                if not buffer:
+                    raise ValueError(
+                        "Input data is empty or could not be read."
+                    )
+
                 output = None
                 if mode == "c":
-                    output = safelz4.compress(buffer)
+                    output = safelz4.compress(
+                        buffer,
+                    )
                 else:
                     output = safelz4.decompress(buffer)
 
-                # write out to BinaryIO
                 args.output.write(output)
             else:
-                try:
-                    file = None
-                    if mode == "c":
-                        # Compression: read from input file, write to compressed
-                        # file.
-                        block_size = args.block_size
-                        block_mode = (
-                            safelz4.BlockMode.Independent
-                            if args.block_independence
-                            else safelz4.BlockMode.Linked
-                        )
-                        block_checksums = args.block_checksums
-                        content_checksum = args.content_checksum
-                        legacy_frame = args.legacy_frame
+                # Streaming with a buffer for large files
+                if mode == "c":
+                    with safelz4.open(
+                        args.output.name,
+                        mode="wb",
+                        block_size=args.block_size,
+                        block_mode=safelz4.BlockMode.Independent
+                        if args.block_independence
+                        else safelz4.BlockMode.Linked,
+                        content_checksum=args.content_checksum,
+                        block_checksums=args.block_checksums,
+                        legacy_frame=args.legacy_frame,
+                    ) as comp_file:
+                        while content := args.infile.read(args.buffer_size):
+                            comp_file.write(content)
+                else:
+                    with safelz4.open(
+                        args.infile.name, mode="rb"
+                    ) as decomp_file:
+                        while content := decomp_file.read(args.buffer_size):
+                            args.output.write(content)
 
-                        file = safelz4.open(
-                            args.output.name,
-                            mode="wb",
-                            block_size=block_size,
-                            block_mode=block_mode,
-                            block_checksums=block_checksums,
-                            content_checksum=content_checksum,
-                            legacy_frame=legacy_frame,
-                        )
-                        if args.buffer_size == -1:
-                            buffer = args.infile.read(-1)
-                            file.write(buffer)
-                        else:
-                            while content := args.infile.read(args.buffer_size):
-                                file.write(content)
-                    else:
-                        # Decompression: read from compressed file, write to output
-                        file = safelz4.open(args.infile.name, mode="rb")
-                        if args.buffer_size == -1:
-                            buffer = file.read(-1)
-                            args.output.write(buffer)
-                        else:
-                            while content := file.read(args.buffer_size):
-                                args.output.write(
-                                    content
-                                )
-
-                finally:
-                    # always close file.
-                    file.close()
-
-        # Handle file extension/suffix logic
-        if args.output != _sys.stdout.buffer:
-            output_file, ext = _os.path.splitext(args.output.name)
-            suffix = args.suffix
-
-            # Add proper suffix if not present
-            if not ext == suffix:
-                new_name = output_file + suffix
-                _os.replace(args.output.name, new_name)
-
-        # Remove input file if dispose flag is set
-        if args.dispose and args.infile != _sys.stdin.buffer:
+        # Final cleanup and file handling
+        if args.dispose and args.infile.name != "<stdin>":
             _os.remove(args.infile.name)
-    except Exception as e:
-        print(e, file=_sys.stderr)
+
+        if mode == "c" and args.output.name != "<stdout>":
+            # Check if output file has correct suffix and rename if necessary
+            base, ext = _os.path.splitext(args.output.name)
+            if ext != args.suffix:
+                new_name = base + args.suffix
+                args.output.close()  # Must close the file before renaming
+                _os.rename(args.output.name, new_name)
+
+    except (ValueError, safelz4.LZ4Exception, safelz4.error.LZ4BlockError) as e:
+        print(f"Error: {e}", file=_sys.stderr)
         return 1
+    except FileNotFoundError as e:
+        print(f"Error: File not found. {e}", file=_sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}", file=_sys.stderr)
+        return 1
+    finally:
+        # Ensure all file handles are closed
+        if args.infile and args.infile.name != "<stdin>":
+            args.infile.close()
+        if args.output and args.output.name != "<stdout>":
+            args.output.close()
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    _sys.exit(main())

--- a/py/safelz4/_cli/_entry.py
+++ b/py/safelz4/_cli/_entry.py
@@ -6,9 +6,7 @@ from argparse import FileType
 
 import safelz4
 
-from typing import Literal, Final
-
-DEFAULT_BUFFER_READ: Final = 8
+from typing import Literal
 
 
 def simple_blocksize_type(value: str) -> safelz4.BlockSize:
@@ -49,10 +47,10 @@ def _parse_argument() -> argparse.Namespace:
         prog="slz4",
         description="LZ4 compression and decompression utility",
         epilog="Examples:\n"
-        "  %(prog)s -c -b input.txt output.bin\n"
-        "  %(prog)s -d -f compressed.lz4 output.txt\n"
-        "  %(prog)s -c -f largefile.bin compressed.lz4\n"
-        "cat input.txt |  %(prog)s -c -f -o compressed.lz4",
+        "  %(prog)s -cb input.txt output.lz4\n"
+        "  %(prog)s -df output.lz4 output.txt\n"
+        "  %(prog)s -cf dickens.txy dickens.lz4\n"
+        "cat input.txt |  %(prog)s -cfo input.txt.lz4",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
@@ -112,7 +110,7 @@ def _parse_argument() -> argparse.Namespace:
         "-s",
         "--size",
         type=int,
-        default=0,  # Changed from False to 0
+        default=0,
         help="If size is not included set decompression size",
     )
 
@@ -141,7 +139,7 @@ def _parse_argument() -> argparse.Namespace:
         help="suffix for compressed files (default: .lz4)",
     )
 
-    # IO files
+    # infile files
     parser.add_argument(
         "infile",
         nargs="?",
@@ -165,96 +163,101 @@ def _parse_argument() -> argparse.Namespace:
 
 
 def main():
-    args = _parse_argument()
+    """entry cli function"""
+    try:
+        args = _parse_argument()
+        mode = _handle_args_mode(args.compress, args.decompress)
 
-    mode = _handle_args_mode(args.compress, args.decompress)
-
-    if args.block:
-        buffer = args.infile.read(-1)
-        output = None
-        if mode == "c":
-            if args.include_size:
-                output = safelz4.block.compress_prepend_size(buffer)
-            else:
-                output = safelz4.block.compress(buffer)
-        else:
-            if args.include_size:
-                output = safelz4.block.decompress_size_prepended(buffer)
-            else:
-                output = safelz4.block.decompress(buffer, args.size)
-
-        args.output.write(output)
-    else:
-        # Check if using stdin (not stdout)
-        if args.infile.name == "<stdin>":
+        if args.block:
             buffer = args.infile.read(-1)
             output = None
             if mode == "c":
-                output = safelz4.compress(buffer)
+                if args.include_size:
+                    output = safelz4.block.compress_prepend_size(buffer)
+                else:
+                    output = safelz4.block.compress(buffer)
             else:
-                output = safelz4.decompress(buffer)
+                if args.include_size:
+                    output = safelz4.block.decompress_size_prepended(buffer)
+                else:
+                    output = safelz4.block.decompress(buffer, args.size)
 
-            # write out to BinaryIO
             args.output.write(output)
         else:
-            file = None
-            if mode == "c":
-                # Compression: read from input file, write to compressed file
-                block_size = args.block_size
-                block_mode = (
-                    safelz4.BlockMode.Independent
-                    if args.block_independence
-                    else safelz4.BlockMode.Linked
-                )
-                block_checksums = args.block_checksums  # Fixed variable name
-                content_checksum = args.content_checksum
-                legacy_frame = args.legacy_frame
-
-                file = safelz4.open(
-                    args.output.name,  # Fixed variable name
-                    mode="wb",
-                    block_size=block_size,
-                    block_mode=block_mode,
-                    block_checksums=block_checksums,
-                    content_checksum=content_checksum,
-                    legacy_frame=legacy_frame,
-                )
-                if args.buffer_size == -1:
-                    buffer = args.infile.read(-1)
-                    file.write(buffer)
+            # Check if using stdin (not stdout)
+            if args.infile.name == "<stdin>":
+                buffer = args.infile.read(-1)
+                output = None
+                if mode == "c":
+                    output = safelz4.compress(buffer)
                 else:
-                    while content := args.infile.read(
-                        args.buffer_size
-                    ):  # Fixed variable access
-                        file.write(content)
+                    output = safelz4.decompress(buffer)
+
+                # write out to BinaryIO
+                args.output.write(output)
             else:
-                # Decompression: read from compressed file, write to output
-                file = safelz4.open(args.infile.name, mode="rb")
-                if args.buffer_size == -1:
-                    buffer = file.read(-1)
-                    args.output.write(buffer)
+                file = None
+                if mode == "c":
+                    # Compression: read from input file, write to compressed
+                    # file.
+                    block_size = args.block_size
+                    block_mode = (
+                        safelz4.BlockMode.Independent
+                        if args.block_independence
+                        else safelz4.BlockMode.Linked
+                    )
+                    block_checksums = (
+                        args.block_checksums
+                    )  # Fixed variable name
+                    content_checksum = args.content_checksum
+                    legacy_frame = args.legacy_frame
+
+                    file = safelz4.open(
+                        args.output.name,  # Fixed variable name
+                        mode="wb",
+                        block_size=block_size,
+                        block_mode=block_mode,
+                        block_checksums=block_checksums,
+                        content_checksum=content_checksum,
+                        legacy_frame=legacy_frame,
+                    )
+                    if args.buffer_size == -1:
+                        buffer = args.infile.read(-1)
+                        file.write(buffer)
+                    else:
+                        while content := args.infile.read(args.buffer_size):
+                            file.write(content)
                 else:
-                    while content := file.read(args.buffer_size):
-                        args.output.write(content)  # Fixed variable name
+                    # Decompression: read from compressed file, write to output
+                    file = safelz4.open(args.infile.name, mode="rb")
+                    if args.buffer_size == -1:
+                        buffer = file.read(-1)
+                        args.output.write(buffer)
+                    else:
+                        while content := file.read(args.buffer_size):
+                            args.output.write(content)  # Fixed variable name
 
-            # close file
-            file.close()
-            args.infile.close()
-            args.output.close()
+                # close file
+                file.close()
+                args.infile.close()
+                args.output.close()
 
-    # Handle file extension/suffix logic
-    if args.output.name != "<stdout>":  # Fixed condition
-        output_file, ext = _os.path.splitext(args.output.name)
-        suffix = args.suffix
+        # Handle file extension/suffix logic
+        if args.output.name != "<stdout>":  # Fixed condition
+            output_file, ext = _os.path.splitext(args.output.name)
+            suffix = args.suffix
 
-        # Add proper suffix if not present
-        if not ext == suffix:
-            new_name = output_file + suffix
-            _os.replace(args.output.name, new_name)
+            # Add proper suffix if not present
+            if not ext == suffix:
+                new_name = output_file + suffix
+                _os.replace(args.output.name, new_name)
 
-    # Remove input file if dispose flag is set
-    if args.dispose and args.infile.name != "<stdin>":
-        _os.remove(args.infile.name)
+        # Remove input file if dispose flag is set
+        if args.dispose and args.infile.name != "<stdin>":
+            _os.remove(args.infile.name)
+    except Exception as e:
+        print(e)
+        return 1
 
 
 if __name__ == "__main__":

--- a/py/safelz4/_cli/_entry.py
+++ b/py/safelz4/_cli/_entry.py
@@ -1,0 +1,261 @@
+import os as _os
+import sys as _sys
+
+import argparse
+from argparse import FileType
+
+import safelz4
+
+from typing import Literal, Final
+
+DEFAULT_BUFFER_READ: Final = 8
+
+
+def simple_blocksize_type(value: str) -> safelz4.BlockSize:
+    """Simple converter that only accepts enum names."""
+    name_map = {
+        "auto": safelz4.BlockSize.Auto,
+        "64kb": safelz4.BlockSize.Max64KB,
+        "256kb": safelz4.BlockSize.Max256KB,
+        "1mb": safelz4.BlockSize.Max1MB,
+        "4mb": safelz4.BlockSize.Max4MB,
+        "8mb": safelz4.BlockSize.Max8MB,
+    }
+
+    lower_value = value.lower()
+    if lower_value in name_map:
+        return name_map[lower_value]
+
+    raise argparse.ArgumentTypeError(
+        f"Invalid block size: {value}. Valid options: "
+        f"{', '.join(name_map.keys())}"
+    )
+
+
+def _handle_args_mode(
+    compression: bool, decompression: bool
+) -> Literal["c", "d"]:
+    if compression:
+        return "c"
+    elif decompression:
+        return "d"
+    else:
+        raise ValueError("no other mode is supported.")
+
+
+def _parse_argument() -> argparse.Namespace:
+    """Parse stdin to interface with safelz4 lib."""
+    parser = argparse.ArgumentParser(
+        prog="slz4",
+        description="LZ4 compression and decompression utility",
+        epilog="Examples:\n"
+        "  %(prog)s -c -b input.txt output.bin\n"
+        "  %(prog)s -d -f compressed.lz4 output.txt\n"
+        "  %(prog)s -c -f largefile.bin compressed.lz4\n"
+        "cat input.txt |  %(prog)s -c -f -o compressed.lz4",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "-c", "--compress", action="store_true", help="compress input file"
+    )
+    mode_group.add_argument(
+        "-d", "--decompress", action="store_true", help="decompress input file"
+    )
+
+    file_format_group = parser.add_mutually_exclusive_group(required=True)
+    file_format_group.add_argument(
+        "-f", "--frame", action="store_true", help="Frame file format"
+    )
+
+    file_format_group.add_argument(
+        "-b", "--block", action="store_true", help="Block file format"
+    )
+
+    frame_group = parser.add_argument_group("frame info option")
+
+    frame_group.add_argument(
+        "--block-size",
+        type=simple_blocksize_type,
+        default=safelz4.BlockSize.Auto,
+        metavar="SIZE",
+        help="block size: auto, 64kb, 256kb, 1mb, 4mb, 8mb (default: auto)",
+    )
+
+    frame_group.add_argument(
+        "--block-independence",
+        action="store_true",
+        default=False,
+        help="compress blocks independently (default: False)",
+    )
+
+    frame_group.add_argument(
+        "--content-checksum", action="store_true", help="add content checksum"
+    )
+    frame_group.add_argument(
+        "--block-checksums", action="store_true", help="add block checksums"
+    )
+    frame_group.add_argument(
+        "--legacy-frame", action="store_true", help="add legacy frame"
+    )
+
+    block_group = parser.add_argument_group("block option")
+    block_group.add_argument(
+        "-i",
+        "--include-size",
+        action="store_true",
+        default=False,
+        help="handle preappend size of block.",
+    )
+    block_group.add_argument(
+        "-s",
+        "--size",
+        type=int,
+        default=0,  # Changed from False to 0
+        help="If size is not included set decompression size",
+    )
+
+    # performance optional
+    perf_group = parser.add_argument_group("frame performance options")
+    perf_group.add_argument(
+        "--buffer-size",
+        type=int,
+        default=-1,
+        metavar="BYTES",
+        help="I/O buffer size in bytes (default: -1)",
+    )
+
+    # file operation
+    file_group = parser.add_argument_group("file handling")
+    file_group.add_argument(
+        "-p",
+        "--dispose",
+        action="store_true",
+        default=False,
+        help="remove input file after compression/decompression",
+    )
+    file_group.add_argument(
+        "--suffix",
+        default=".lz4",
+        help="suffix for compressed files (default: .lz4)",
+    )
+
+    # IO files
+    parser.add_argument(
+        "infile",
+        nargs="?",
+        type=FileType("rb"),
+        default=_sys.stdin.buffer,
+        help="input file path (default: stdin)",
+    )
+
+    # output file
+    parser.add_argument(
+        "-o",
+        "--output",
+        nargs="?",
+        type=FileType("wb"),
+        default=_sys.stdout.buffer,
+        help="output file path (defaults based on mode)",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = _parse_argument()
+
+    mode = _handle_args_mode(args.compress, args.decompress)
+
+    if args.block:
+        buffer = args.infile.read(-1)
+        output = None
+        if mode == "c":
+            if args.include_size:
+                output = safelz4.block.compress_prepend_size(buffer)
+            else:
+                output = safelz4.block.compress(buffer)
+        else:
+            if args.include_size:
+                output = safelz4.block.decompress_size_prepended(buffer)
+            else:
+                output = safelz4.block.decompress(buffer, args.size)
+
+        args.output.write(output)
+    else:
+        # Check if using stdin (not stdout)
+        if args.infile.name == "<stdin>":
+            buffer = args.infile.read(-1)
+            output = None
+            if mode == "c":
+                output = safelz4.compress(buffer)
+            else:
+                output = safelz4.decompress(buffer)
+
+            # write out to BinaryIO
+            args.output.write(output)
+        else:
+            file = None
+            if mode == "c":
+                # Compression: read from input file, write to compressed file
+                block_size = args.block_size
+                block_mode = (
+                    safelz4.BlockMode.Independent
+                    if args.block_independence
+                    else safelz4.BlockMode.Linked
+                )
+                block_checksums = args.block_checksums  # Fixed variable name
+                content_checksum = args.content_checksum
+                legacy_frame = args.legacy_frame
+
+                file = safelz4.open(
+                    args.output.name,  # Fixed variable name
+                    mode="wb",
+                    block_size=block_size,
+                    block_mode=block_mode,
+                    block_checksums=block_checksums,
+                    content_checksum=content_checksum,
+                    legacy_frame=legacy_frame,
+                )
+                if args.buffer_size == -1:
+                    buffer = args.infile.read(-1)
+                    file.write(buffer)
+                else:
+                    while content := args.infile.read(
+                        args.buffer_size
+                    ):  # Fixed variable access
+                        file.write(content)
+            else:
+                # Decompression: read from compressed file, write to output
+                file = safelz4.open(args.infile.name, mode="rb")
+                if args.buffer_size == -1:
+                    buffer = file.read(-1)
+                    args.output.write(buffer)
+                else:
+                    while content := file.read(args.buffer_size):
+                        args.output.write(content)  # Fixed variable name
+
+            # close file
+            file.close()
+            args.infile.close()
+            args.output.close()
+
+    # Handle file extension/suffix logic
+    if args.output.name != "<stdout>":  # Fixed condition
+        output_file, ext = _os.path.splitext(args.output.name)
+        suffix = args.suffix
+
+        # Add proper suffix if not present
+        if not ext == suffix:
+            new_name = output_file + suffix
+            _os.replace(args.output.name, new_name)
+
+    # Remove input file if dispose flag is set
+    if args.dispose and args.infile.name != "<stdin>":
+        _os.remove(args.infile.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/safelz4/frame/__init__.pyi
+++ b/py/safelz4/frame/__init__.pyi
@@ -176,9 +176,9 @@ def decompress_file(filename: Union[os.PathLike, str]) -> bytes:
     Example:
 
     ```python
-    from safelz4 import decompress
+    from safelz4 import decompress_file
 
-    output = decompress("datafile.lz4")
+    output = decompress_file("datafile.lz4")
     ```
 
     """
@@ -223,11 +223,11 @@ def compress_into_file(filename: Union[os.PathLike, str], input: bytes) -> None:
 
     Example:
     ```python
-    from safelz4.frame import compress
+    import safelz4
 
     with open("datafile.txt", "rb") as file:
         buffer = file.read(-1)
-        compress_into_file("datafile.lz4", buf_f)
+        safelz4.compress_into_file("datafile.lz4", buffer)
 
     ```
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ authors = [{ name = 'Luca Vivona', email = "lucavivona01@gmail.com" }]
 description = "safe LZ4 data compress library."
 readme = { file = "README.md", content-type = "text/markdown" }
 
+[project.scripts]
+slz4 = "safelz4.__main__:main"
+
 [project.optional-dependencies]
 quality = [
     "black==22.3",   # after updating to black 2023, also update Python version in pyproject.toml to 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ description = "safe LZ4 data compress library."
 readme = { file = "README.md", content-type = "text/markdown" }
 
 [project.scripts]
-slz4 = "safelz4.__main__:main"
+slz4 = "safelz4.__main__:run"
 
 [project.optional-dependencies]
 quality = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,39 +19,30 @@ def test_compress_and_decompress_file(block_mode):
         tmp_path = Path(tmp_dir)
         output_file = tmp_path / "output.slz4"
         input_file = FILE_1Kb
-        
+
+        # Compress
         with open(output_file, "wb") as stdout:
-            try:
-                # Compress
-                result = subprocess.run(
-                    ["slz4", "-c", block_mode, "-i", str(input_file)],
-                    stdout=stdout,
-                    check=True,
-                )
-                print(f"Compression stdout: {result.stdout}")
-                print(f"Compression stderr: {result.stderr}")
-                print(f"Output file exists: {output_file.exists()}")
-                if output_file.exists():
-                    print(f"Output file size: {output_file.stat().st_size}")
-                
-                assert output_file.exists(), f"Output file was not created: {output_file}"
-                assert output_file.stat().st_size > 0, f"Output file is empty: {output_file}"
+            subprocess.run(
+                ["slz4", "-c", block_mode, "-i", str(input_file)],
+                stdout=stdout,
+                check=True,
+            )
 
-                # Decompress
-                result = subprocess.run(
-                    ["slz4", "-d", "-i", block_mode, str(output_file)],
-                    check=True,
-                    capture_output=True,
-                    text=True
-                )
-                print(f"Decompression stdout: {result.stdout}")
-                print(f"Decompression stderr: {result.stderr}")
-                
-                with open(FILE_1Kb, "r") as file:
-                    assert result.stdout == file.read()
+        assert (
+            output_file.exists()
+        ), f"Output file was not created: {output_file}"
+        assert (
+            output_file.stat().st_size > 0
+        ), f"Output file is empty: {output_file}"
 
-            except Exception:
-                raise
+        # Decompress
+        result = subprocess.run(
+            ["slz4", "-d", block_mode, "-i", str(output_file)],
+            check=True,
+            capture_output=True,
+        )
+        with open(FILE_1Kb, "rb") as file:
+            assert result.stdout == file.read()
 
 
 def test_block_compress_with_include_size():
@@ -60,26 +51,21 @@ def test_block_compress_with_include_size():
         tmp_path = Path(tmp_dir)
         input_file = tmp_path / "input.txt"
         output_file = tmp_path / "output.slz4"
-        
-        # Write test data to input file
+
         input_file.write_bytes(TEST_TEXT)
-        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
-        
+
         with open(output_file, "wb") as stdout:
-            result = subprocess.run(
+            subprocess.run(
                 ["slz4", "-c", "-b", "--include-size", str(input_file)],
                 stdout=stdout,
                 check=True,
             )
-            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
-            print(f"Output file exists: {output_file.exists()}")
-        
+
         result = subprocess.run(
             ["slz4", "-d", "-b", "--include-size", str(output_file)],
             check=True,
             capture_output=True,
         )
-        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
         assert result.stdout == TEST_TEXT
 
 
@@ -89,26 +75,28 @@ def test_block_decompress_with_manual_size():
         tmp_path = Path(tmp_dir)
         input_file = tmp_path / "input.txt"
         output_file = tmp_path / "output.slz4"
-        
-        # Write test data to input file
+
         input_file.write_bytes(TEST_TEXT)
-        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
-        
+
         with open(output_file, "wb") as stdout:
-            result = subprocess.run(
+            subprocess.run(
                 ["slz4", "-c", "-b", str(input_file)],
                 stdout=stdout,
                 check=True,
             )
-            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
-            print(f"Output file exists: {output_file.exists()}")
-        
+
         result = subprocess.run(
-            ["slz4", "-d", "-b", "--size", str(len(TEST_TEXT)), str(output_file)],
+            [
+                "slz4",
+                "-d",
+                "-b",
+                "--size",
+                str(len(TEST_TEXT)),
+                str(output_file),
+            ],
             check=True,
             capture_output=True,
         )
-        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
         assert result.stdout == TEST_TEXT
 
 
@@ -118,30 +106,31 @@ def test_frame_options_blocksize():
         tmp_path = Path(tmp_dir)
         input_file = tmp_path / "input.txt"
         output_file = tmp_path / "output.slz4"
-        
-        # Write test data to input file
+
         input_file.write_bytes(TEST_TEXT)
-        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
-        
+
         with open(output_file, "wb") as stdout:
-            result = subprocess.run(
+            subprocess.run(
                 [
-                    "slz4", "-c", "-f", "--block-size", "256kb",
-                    "--content-checksum", "--block-checksums", "--block-independence",
+                    "slz4",
+                    "-c",
+                    "-f",
+                    "--block-size",
+                    "256kb",
+                    "--content-checksum",
+                    "--block-checksums",
+                    "--block-independence",
                     str(input_file),
                 ],
                 stdout=stdout,
                 check=True,
             )
-            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
-            print(f"Output file exists: {output_file.exists()}")
-        
+
         result = subprocess.run(
             ["slz4", "-d", "-f", str(output_file)],
             check=True,
             capture_output=True,
         )
-        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
         assert result.stdout == TEST_TEXT
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,174 @@
+import subprocess
+import os
+import pytest
+import tempfile
+from pathlib import Path
+
+pwd = os.path.dirname(os.path.abspath(__file__))
+samples = os.path.join(pwd, "..", "benches", "samples")
+FILE_1Kb = os.path.join(samples, "compression_1k.txt")
+
+# Test data constant
+TEST_TEXT = b"This is test data for compression testing. " * 100
+
+
+@pytest.mark.parametrize("block_mode", ["-b"])
+def test_compress_and_decompress_file(block_mode):
+    """Test round-trip compression and decompression via CLI."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        output_file = tmp_path / "output.slz4"
+        input_file = FILE_1Kb
+        
+        with open(output_file, "wb") as stdout:
+            try:
+                # Compress
+                result = subprocess.run(
+                    ["slz4", "-c", block_mode, "-i", str(input_file)],
+                    stdout=stdout,
+                    check=True,
+                )
+                print(f"Compression stdout: {result.stdout}")
+                print(f"Compression stderr: {result.stderr}")
+                print(f"Output file exists: {output_file.exists()}")
+                if output_file.exists():
+                    print(f"Output file size: {output_file.stat().st_size}")
+                
+                assert output_file.exists(), f"Output file was not created: {output_file}"
+                assert output_file.stat().st_size > 0, f"Output file is empty: {output_file}"
+
+                # Decompress
+                result = subprocess.run(
+                    ["slz4", "-d", "-i", block_mode, str(output_file)],
+                    check=True,
+                    capture_output=True,
+                    text=True
+                )
+                print(f"Decompression stdout: {result.stdout}")
+                print(f"Decompression stderr: {result.stderr}")
+                
+                with open(FILE_1Kb, "r") as file:
+                    assert result.stdout == file.read()
+
+            except Exception:
+                raise
+
+
+def test_block_compress_with_include_size():
+    """Test block compression with --include-size and decompression using it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        input_file = tmp_path / "input.txt"
+        output_file = tmp_path / "output.slz4"
+        
+        # Write test data to input file
+        input_file.write_bytes(TEST_TEXT)
+        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
+        
+        with open(output_file, "wb") as stdout:
+            result = subprocess.run(
+                ["slz4", "-c", "-b", "--include-size", str(input_file)],
+                stdout=stdout,
+                check=True,
+            )
+            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
+            print(f"Output file exists: {output_file.exists()}")
+        
+        result = subprocess.run(
+            ["slz4", "-d", "-b", "--include-size", str(output_file)],
+            check=True,
+            capture_output=True,
+        )
+        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
+        assert result.stdout == TEST_TEXT
+
+
+def test_block_decompress_with_manual_size():
+    """Test block decompression with manual --size when not using include-size."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        input_file = tmp_path / "input.txt"
+        output_file = tmp_path / "output.slz4"
+        
+        # Write test data to input file
+        input_file.write_bytes(TEST_TEXT)
+        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
+        
+        with open(output_file, "wb") as stdout:
+            result = subprocess.run(
+                ["slz4", "-c", "-b", str(input_file)],
+                stdout=stdout,
+                check=True,
+            )
+            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
+            print(f"Output file exists: {output_file.exists()}")
+        
+        result = subprocess.run(
+            ["slz4", "-d", "-b", "--size", str(len(TEST_TEXT)), str(output_file)],
+            check=True,
+            capture_output=True,
+        )
+        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
+        assert result.stdout == TEST_TEXT
+
+
+def test_frame_options_blocksize():
+    """Test frame compression with non-default block size."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        input_file = tmp_path / "input.txt"
+        output_file = tmp_path / "output.slz4"
+        
+        # Write test data to input file
+        input_file.write_bytes(TEST_TEXT)
+        print(f"Input file created: {input_file}, size: {len(TEST_TEXT)}")
+        
+        with open(output_file, "wb") as stdout:
+            result = subprocess.run(
+                [
+                    "slz4", "-c", "-f", "--block-size", "256kb",
+                    "--content-checksum", "--block-checksums", "--block-independence",
+                    str(input_file),
+                ],
+                stdout=stdout,
+                check=True,
+            )
+            print(f"Compression result: stdout='{result.stdout}', stderr='{result.stderr}'")
+            print(f"Output file exists: {output_file.exists()}")
+        
+        result = subprocess.run(
+            ["slz4", "-d", "-f", str(output_file)],
+            check=True,
+            capture_output=True,
+        )
+        print(f"Decompression result: stdout length={len(result.stdout) if result.stdout else 0}")
+        assert result.stdout == TEST_TEXT
+
+
+def test_stdin_stdout_roundtrip():
+    """Test stdin to stdout compression and decompression."""
+    compress = subprocess.run(
+        ["slz4", "-c", "-f"],
+        input=TEST_TEXT,
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    decompress = subprocess.run(
+        ["slz4", "-d", "-f"],
+        input=compress.stdout,
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    assert decompress.stdout == TEST_TEXT
+
+
+def test_missing_required_flags():
+    """Test that required flags raise errors."""
+    result = subprocess.run(
+        ["slz4"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert "error" in result.stderr.lower()
+    assert result.returncode != 0


### PR DESCRIPTION
## 📋 Description

This pull request adds a simple CLI feature called `slz4`. The CLI feature is added through a new Python script that leverages the `argparse` module to create a command-line utility for the `safelz4` library.

### `_parse_argument()` Function

This function is where the **CLI is defined**. It uses Python's `argparse` to set up all the command-line options and flags, such as:

* **Mode Flags:** `-c` (compress) and `-d` (decompress).
* **Format Flags:** `-f` (frame) and `-b` (block).
* **Option Arguments:** `--block-size`, `--buffer-size`, `--size`, and `--suffix`.
* **File Arguments:** `infile` and `-o, --output`.

It handles the parsing of these arguments, ensuring they're of the correct type and providing helpful usage and error messages.

### `main()` Function

This function serves as the **operational core** of the CLI. After the arguments are parsed, `main()` uses conditional logic to execute the appropriate `safelz4` function.

* It checks the `mode` and `file_format` flags to decide whether to call `safelz4.compress`, `safelz4.decompress`, or the `safelz4.block` equivalents.
* It manages **file I/O**, handling both standard input/output streams and disk files.
* It includes logic to handle different compression and decompression options, such as prepending the size for block mode or using streaming for large files.
* It performs cleanup, like removing the source file if the `--dispose` flag is used.

## 🧩 Related Issues

NRI

---

## 🧪 Testing

The changes were tested locally by running various commands and verifying the output and file system state.

- **Commands used:**
  - `python slz4.py -cf test.txt -o test.lz4`
  - `python slz4.py -df test.lz4 -o test_decompressed.txt`
  - Tests were also performed with the `-p` (dispose) and `--suffix` flags to ensure correct file removal and renaming.
- **Platforms tested:** Linux (Ubuntu) | MacOS

---

## 🔗 Python API Changes (if applicable)

N/A