### PR TITLE
Strip debug symbols from productive library builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ pyo3 = { version = "0.27", features = ['abi3', 'abi3-py38'] }
 twox-hash = { version = "1.6.3", default-features = false }
 memmap2 = "0.9"
 lz4_flex = { version = "=0.12", default-features = false, features = ["frame"]}
+
+[profile.release]
+strip = true


### PR DESCRIPTION
## 📋 Description

It is a common practice to strip debug symbols from production binaries. In certain use-cases, e.g. lightweight Docker images, a smaller filesystem footprint of dependencies is desired.

This PR tells Cargo to strip debug symbols from _safelz4_rs.abi3.so for production builds.

## 🧪 Testing

When using a current wheel of safelz4, it clocks in at 1.1 megabytes in the venv. The size is reduced to 792 kilobytes with this patch applied.

I also tested building the wheel in dev profile with uv and it still works as expected, producing a non-stripped library with debug_info.
